### PR TITLE
Draft log: reassign picks drag-and-drop

### DIFF
--- a/scripts/update-ncaa-teams.cjs
+++ b/scripts/update-ncaa-teams.cjs
@@ -1,0 +1,143 @@
+const PocketBase = require('pocketbase/cjs');
+
+const pb = new PocketBase('https://pocketbase-production-96d3.up.railway.app');
+
+// New bracket — 68 teams (64 + 4 play-in slots listed as combined entries)
+// Play-in teams get seed 11 or 16 with a combined name
+const newTeams = [
+  // East
+  { region: 'East', seed: 1,  name: 'Duke Blue Devils' },
+  { region: 'East', seed: 2,  name: 'UConn Huskies' },
+  { region: 'East', seed: 3,  name: 'Michigan State Spartans' },
+  { region: 'East', seed: 4,  name: 'Kansas Jayhawks' },
+  { region: 'East', seed: 5,  name: "St. John's Red Storm" },
+  { region: 'East', seed: 6,  name: 'Louisville Cardinals' },
+  { region: 'East', seed: 7,  name: 'UCLA Bruins' },
+  { region: 'East', seed: 8,  name: 'Ohio State Buckeyes' },
+  { region: 'East', seed: 9,  name: 'TCU Horned Frogs' },
+  { region: 'East', seed: 10, name: 'UCF Knights' },
+  { region: 'East', seed: 11, name: 'South Florida Bulls' },
+  { region: 'East', seed: 12, name: 'Northern Iowa Panthers' },
+  { region: 'East', seed: 13, name: 'Cal Baptist Lancers' },
+  { region: 'East', seed: 14, name: 'North Dakota State Bison' },
+  { region: 'East', seed: 15, name: 'Furman Paladins' },
+  { region: 'East', seed: 16, name: 'Siena Saints' },
+  // West
+  { region: 'West', seed: 1,  name: 'Arizona Wildcats' },
+  { region: 'West', seed: 2,  name: 'Purdue Boilermakers' },
+  { region: 'West', seed: 3,  name: 'Gonzaga Bulldogs' },
+  { region: 'West', seed: 4,  name: 'Arkansas Razorbacks' },
+  { region: 'West', seed: 5,  name: 'Wisconsin Badgers' },
+  { region: 'West', seed: 6,  name: 'BYU Cougars' },
+  { region: 'West', seed: 7,  name: 'Miami Hurricanes' },
+  { region: 'West', seed: 8,  name: 'Villanova Wildcats' },
+  { region: 'West', seed: 9,  name: 'Utah State Aggies' },
+  { region: 'West', seed: 10, name: 'Missouri Tigers' },
+  { region: 'West', seed: 11, name: 'Texas / NC State' },  // play-in
+  { region: 'West', seed: 12, name: 'High Point Panthers' },
+  { region: 'West', seed: 13, name: 'Hawaii Rainbow Warriors' },
+  { region: 'West', seed: 14, name: 'Kennesaw State Owls' },
+  { region: 'West', seed: 15, name: 'Queens Royals' },
+  { region: 'West', seed: 16, name: 'LIU Sharks' },
+  // Midwest
+  { region: 'Midwest', seed: 1,  name: 'Michigan Wolverines' },
+  { region: 'Midwest', seed: 2,  name: 'Iowa State Cyclones' },
+  { region: 'Midwest', seed: 3,  name: 'Virginia Cavaliers' },
+  { region: 'Midwest', seed: 4,  name: 'Alabama Crimson Tide' },
+  { region: 'Midwest', seed: 5,  name: 'Texas Tech Red Raiders' },
+  { region: 'Midwest', seed: 6,  name: 'Tennessee Volunteers' },
+  { region: 'Midwest', seed: 7,  name: 'Kentucky Wildcats' },
+  { region: 'Midwest', seed: 8,  name: 'Georgia Bulldogs' },
+  { region: 'Midwest', seed: 9,  name: 'Saint Louis Billikens' },
+  { region: 'Midwest', seed: 10, name: 'Santa Clara Broncos' },
+  { region: 'Midwest', seed: 11, name: 'Miami (OH) / SMU' },  // play-in
+  { region: 'Midwest', seed: 12, name: 'Akron Zips' },
+  { region: 'Midwest', seed: 13, name: 'Hofstra Pride' },
+  { region: 'Midwest', seed: 14, name: 'Wright State Raiders' },
+  { region: 'Midwest', seed: 15, name: 'Tennessee State Tigers' },
+  { region: 'Midwest', seed: 16, name: 'UMBC / Howard' },  // play-in
+  // South
+  { region: 'South', seed: 1,  name: 'Florida Gators' },
+  { region: 'South', seed: 2,  name: 'Houston Cougars' },
+  { region: 'South', seed: 3,  name: 'Illinois Fighting Illini' },
+  { region: 'South', seed: 4,  name: 'Nebraska Cornhuskers' },
+  { region: 'South', seed: 5,  name: 'Vanderbilt Commodores' },
+  { region: 'South', seed: 6,  name: 'North Carolina Tar Heels' },
+  { region: 'South', seed: 7,  name: "Saint Mary's Gaels" },
+  { region: 'South', seed: 8,  name: 'Clemson Tigers' },
+  { region: 'South', seed: 9,  name: 'Iowa Hawkeyes' },
+  { region: 'South', seed: 10, name: 'Texas A&M Aggies' },
+  { region: 'South', seed: 11, name: 'VCU Rams' },
+  { region: 'South', seed: 12, name: 'McNeese Cowboys' },
+  { region: 'South', seed: 13, name: 'Troy Trojans' },
+  { region: 'South', seed: 14, name: 'Penn Quakers' },
+  { region: 'South', seed: 15, name: 'Idaho Vandals' },
+  { region: 'South', seed: 16, name: 'Prairie View / Lehigh' },  // play-in
+];
+
+// Existing IDs sorted by region+seed (from current DB)
+const existingIds = {
+  East: {
+    1: '4ksmr54uxehwcns', 2: '4yingisg1qnj2uv', 3: 'o83ppcz71h1v89p', 4: 'rlbc41o0yzzz88m',
+    5: 'oa90bvokfzg0gn5', 6: '6mxfjcutazpwtrt', 7: 'zgohn24edzcf1ry', 8: '7q3z6ag39uospnn',
+    9: '01uppikpo64r8jw', 10: '7ax3054207780x2', 11: 'cv36tyuacujj18m', 12: 'wxh8e8ka6mnk9yd',
+    13: '1u66l8kz29y3rit', 14: 'a12c0p9y7h5ma0j', 15: 'uh9ctrfznn0dume', 16: '0cap4362xbcv270',
+  },
+  Midwest: {
+    1: 'ven9q1940a6iljx', 2: 'myy8i1fqgiwfc3g', 3: 'w590ok0yb9e1hmu', 4: 'i9br1f7p63wj10r',
+    5: 'n4mkosjrm6n9uqb', 6: '02bq9xkayproodt', 7: 'okusxagjfhua6r9', 8: '6v67zvckchgdhav',
+    9: 'j055jwbr5q3trl6', 10: 'qk0fk1cgv44xfgq', 11: 'rsj20vftsqnofnl', 12: '22vhtmnvtg7sfgt',
+    13: 'xjoef060bp8td54', 14: 'gc2z2922a5tkt8a', 15: 's366ogcsgmqnwq4', 16: '0h78b1zgkk1c44l',
+  },
+  South: {
+    1: 'gysuivqdxx0se63', 2: 'c6c0o5i3e2ksxpq', 3: 'ylns44m3b0g7z72', 4: 'i3rsx5wz7tfs9i4',
+    5: 'a0wp1zso5zdibyk', 6: '15qs07rfab85uyi', 7: 'gn9b5b7robpfcku', 8: 'elp31p2de45xs70',
+    9: '897482mjuo8cl5y', 10: '261wh9ks6zrr5jd', 11: '8a5g27veljuzxv2', 12: 'aw3z0mt9w0sczmv',
+    13: 'yzsa1rvmd0h7ver', 14: '5kxy4x8fqz9pqc5', 15: '1aijbrxqtpvi1ks', 16: 'uwx4kvgd5pfyyjk',
+  },
+  West: {
+    1: 'hxkhvq0c4gsjm3w', 2: 'n7grf8ofdxnclkn', 3: 'wmrk4cabols01l8', 4: '076a2tzdz9o64fr',
+    5: 'w6sukxiypp5xer7', 6: 'cg8crd8mji2sw5n', 7: 'q6v3010y4adjsjh', 8: 'txoftv96z4ihwxl',
+    9: 'merjx72dwby79kv', 10: 'fw3ek5tek3y2sik', 11: 'm6e0myghiif2v4l', 12: '28kz1kuji31qoxo',
+    13: 'zxxm29pthwf54hf', 14: 'emiwfu7wu6h7lz3', 15: 'pzsr8mo6fkz4flt', 16: '9dlsrb4vosoqgi6',
+  },
+};
+
+async function run() {
+  await pb.collection('_superusers').authWithPassword('ddinsmore8@gmail.com', 'MADcap(123)');
+  console.log('Authenticated');
+
+  let updated = 0, created = 0, errors = 0;
+
+  for (const team of newTeams) {
+    const id = existingIds[team.region]?.[team.seed];
+    try {
+      if (id) {
+        await pb.collection('ncaa_teams').update(id, {
+          name: team.name,
+          region: team.region,
+          seed: team.seed,
+          eliminated_round: '',
+        });
+        console.log(`  ✅ updated ${team.region} #${team.seed} → ${team.name}`);
+        updated++;
+      } else {
+        await pb.collection('ncaa_teams').create({
+          name: team.name,
+          region: team.region,
+          seed: team.seed,
+          eliminated_round: '',
+        });
+        console.log(`  ➕ created ${team.region} #${team.seed} → ${team.name}`);
+        created++;
+      }
+    } catch (e) {
+      console.error(`  ❌ ${team.region} #${team.seed} ${team.name}: ${e.message}`);
+      errors++;
+    }
+  }
+
+  console.log(`\nDone: ${updated} updated, ${created} created, ${errors} errors`);
+}
+
+run().catch(console.error);

--- a/src/routes/admin/+page.server.ts
+++ b/src/routes/admin/+page.server.ts
@@ -290,6 +290,25 @@ export const actions: Actions = {
 		}
 	},
 
+	reassignPick: async ({ request }) => {
+		await ensureAdminAuth();
+		const fd = await request.formData();
+		const pickId = fd.get('pick_id') as string;
+		const toPoolTeamId = fd.get('to_pool_team') as string;
+		if (!pickId || !toPoolTeamId) return fail(400, { reassignError: 'Missing fields' });
+		try {
+			const userId = await resolveUserId(toPoolTeamId);
+			await adminPb.collection('draft_picks').update(pickId, {
+				pool_team: toPoolTeamId,
+				user: userId
+			});
+			return { reassignSuccess: true };
+		} catch (err: unknown) {
+			const pb_err = err as { response?: { message?: string }; message?: string };
+			return fail(500, { reassignError: pb_err?.response?.message ?? pb_err?.message ?? 'Failed to reassign' });
+		}
+	},
+
 	undoPick: async ({ request }) => {
 		await ensureAdminAuth();
 		const formData = await request.formData();

--- a/src/routes/admin/+page.svelte
+++ b/src/routes/admin/+page.svelte
@@ -362,11 +362,56 @@
 	// --- Pick Assignment Panel ---
 	// Shown when draft is live; admin drags NCAA teams onto pool team slots
 	let pickAssignMode = $state(false);
+	let reassignMode = $state(false);
 
 	// ncaaTeamId being dragged in assign mode
 	let assignDragId = $state('');
 	// { poolTeamId, slot } being hovered
 	let assignHoverKey = $state('');
+
+	// Reassign mode state
+	let reassignDragPickId = $state('');   // pick.id being dragged
+	let reassignDragTeamName = $state(''); // display name while dragging
+	let reassignHoverTeamId = $state('');  // pool team being hovered over
+	let reassignPending = $state(false);
+	let reassignError = $state('');
+	let reassignSuccess = $state('');
+
+	function reassignDragStart(e: DragEvent, pickId: string, teamName: string) {
+		reassignDragPickId = pickId;
+		reassignDragTeamName = teamName;
+		e.dataTransfer!.effectAllowed = 'move';
+		e.dataTransfer!.setData('text/plain', pickId);
+	}
+
+	async function reassignDrop(e: DragEvent, toPoolTeamId: string) {
+		e.preventDefault();
+		reassignHoverTeamId = '';
+		const pickId = e.dataTransfer!.getData('text/plain') || reassignDragPickId;
+		reassignDragPickId = '';
+		if (!pickId || !toPoolTeamId) return;
+		reassignPending = true;
+		reassignError = '';
+		reassignSuccess = '';
+		try {
+			const fd = new FormData();
+			fd.set('pick_id', pickId);
+			fd.set('to_pool_team', toPoolTeamId);
+			const res = await fetch('?/reassignPick', { method: 'POST', body: fd, headers: { 'x-sveltekit-action': 'true' } });
+			const json = await res.json();
+			if (json?.type === 'failure' || json?.type === 'error') {
+				reassignError = 'Reassign failed';
+			} else {
+				reassignSuccess = reassignDragTeamName;
+				await invalidateAll();
+			}
+		} catch {
+			reassignError = 'Network error';
+		} finally {
+			reassignPending = false;
+			reassignDragTeamName = '';
+		}
+	}
 
 	function assignDragStart(e: DragEvent, ncaaTeamId: string) {
 		assignDragId = ncaaTeamId;
@@ -383,12 +428,9 @@
 		assignHoverKey = '';
 	}
 
-	// Returns picks already made for a given pool team (via user→poolTeam mapping)
+	// Returns picks already made for a given pool team
 	function picksForTeam(poolTeamId: string) {
-		const userIds = (data.joinRequests ?? [])
-			.filter((r) => r.pool_team === poolTeamId && r.status === 'approved')
-			.map((r) => r.user);
-		return data.picks.filter((p) => userIds.includes(p.user));
+		return data.picks.filter((p) => p.pool_team === poolTeamId || p.expand?.pool_team?.id === poolTeamId);
 	}
 
 	// Shared pick submission — posts directly to avoid DOM sync issues
@@ -676,8 +718,23 @@
 	<!-- Draft Log -->
 	<Card.Card>
 		<Card.CardHeader class="pb-3">
-			<Card.CardTitle class="flex items-center gap-2">
-				<ChartBar class="h-4 w-4" /> Draft Log ({data.picks.length}/{totalPicks})
+			<Card.CardTitle class="flex items-center justify-between gap-2">
+				<span class="flex items-center gap-2"><ChartBar class="h-4 w-4" /> Draft Log ({data.picks.length}/{totalPicks})</span>
+				{#if data.picks.length > 0}
+					<div class="flex items-center gap-2">
+						{#if reassignMode}
+							<span class="text-xs text-muted-foreground">Drag a pick row onto a different pool team card to reassign it.</span>
+						{/if}
+						<Button
+							variant={reassignMode ? 'default' : 'outline'}
+							size="sm"
+							class="h-7 text-xs"
+							onclick={() => { reassignMode = !reassignMode; pickAssignMode = false; }}
+						>
+							{reassignMode ? '← Done' : 'Reassign Picks →'}
+						</Button>
+					</div>
+				{/if}
 			</Card.CardTitle>
 		</Card.CardHeader>
 		<Card.CardContent>
@@ -687,14 +744,31 @@
 				{@const picksByTeam = (data.poolTeams ?? []).map(pt => ({
 					pt,
 					picks: data.picks.filter(p => p.pool_team === pt.id || p.expand?.pool_team?.id === pt.id).sort((a,b) => a.pick_number - b.pick_number)
-				})).filter(g => g.picks.length > 0)}
+				}))}
+				{#if reassignMode && reassignError}
+					<p class="text-xs text-destructive mb-2">{reassignError}</p>
+				{/if}
+				{#if reassignMode && reassignSuccess}
+					<p class="text-xs text-accent mb-2">✅ {reassignSuccess} reassigned.</p>
+				{/if}
 				<div class="grid gap-3 sm:grid-cols-2 lg:grid-cols-3 xl:grid-cols-4 2xl:grid-cols-5">
 					{#each picksByTeam as { pt, picks: teamPicks }}
-						<div class="rounded-lg border border-border bg-card shadow-sm flex flex-col">
+						<!-- svelte-ignore a11y_no_static_element_interactions -->
+						<div
+							class="rounded-lg border shadow-sm flex flex-col transition-colors
+								{reassignMode && reassignHoverTeamId === pt.id ? 'border-primary bg-primary/5' : 'border-border bg-card'}"
+							ondragover={reassignMode ? (e) => { e.preventDefault(); reassignHoverTeamId = pt.id; } : undefined}
+							ondragleave={reassignMode ? () => { if (reassignHoverTeamId === pt.id) reassignHoverTeamId = ''; } : undefined}
+							ondrop={reassignMode ? (e) => reassignDrop(e, pt.id) : undefined}
+						>
 							<!-- Pool team header -->
-							<div class="px-3 py-2 border-b border-border bg-muted/40 rounded-t-lg">
+							<div class="px-3 py-2 border-b border-border rounded-t-lg
+								{reassignMode && reassignHoverTeamId === pt.id ? 'bg-primary/20' : 'bg-muted/40'}">
 								<p class="text-xs font-semibold truncate">{pt.name}</p>
-								<p class="text-xs text-muted-foreground">{teamPicks.length} pick{teamPicks.length !== 1 ? 's' : ''}</p>
+								<p class="text-xs text-muted-foreground">
+									{teamPicks.length} pick{teamPicks.length !== 1 ? 's' : ''}
+									{#if reassignMode}<span class="text-primary/60"> · drop here to reassign</span>{/if}
+								</p>
 							</div>
 							<!-- Pick rows -->
 							<div class="flex flex-col divide-y divide-border">
@@ -703,19 +777,28 @@
 									{@const roundGroup = Math.ceil((pick.draft_round ?? 1) / 2)}
 									{@const regionColor = team?.region === 'East' ? 'bg-blue-100 text-blue-700 dark:bg-blue-900/40 dark:text-blue-300' : team?.region === 'West' ? 'bg-purple-100 text-purple-700 dark:bg-purple-900/40 dark:text-purple-300' : team?.region === 'South' ? 'bg-green-100 text-green-700 dark:bg-green-900/40 dark:text-green-300' : 'bg-orange-100 text-orange-700 dark:bg-orange-900/40 dark:text-orange-300'}
 									{@const groupColor = roundGroup === 1 ? 'bg-blue-500/15 text-blue-400' : roundGroup === 2 ? 'bg-purple-500/15 text-purple-400' : 'bg-orange-500/15 text-orange-400'}
-									<div class="px-3 py-1.5 flex items-center gap-2">
-										<!-- Seed -->
+									<!-- svelte-ignore a11y_no_static_element_interactions -->
+									<div
+										class="px-3 py-1.5 flex items-center gap-2
+											{reassignMode ? 'cursor-grab active:cursor-grabbing hover:bg-primary/5' : ''}
+											{reassignMode && reassignDragPickId === pick.id ? 'opacity-40' : ''}"
+										draggable={reassignMode ? 'true' : 'false'}
+										ondragstart={reassignMode ? (e) => reassignDragStart(e, pick.id, team?.name ?? '?') : undefined}
+										ondragend={reassignMode ? () => { reassignDragPickId = ''; reassignHoverTeamId = ''; } : undefined}
+									>
+										{#if reassignMode}
+											<span class="shrink-0 text-muted-foreground/30 text-xs">⠿</span>
+										{/if}
 										<span class="w-5 shrink-0 text-right text-xs font-bold tabular-nums text-muted-foreground/60">#{team?.seed ?? '?'}</span>
-										<!-- Team name -->
 										<span class="flex-1 text-xs font-medium truncate">{team?.name ?? '?'}</span>
-										<!-- Region + group badges -->
 										<span class="shrink-0 rounded px-1 py-0.5 text-xs leading-none {regionColor}">{team?.region?.slice(0,1) ?? '?'}</span>
 										<span class="shrink-0 rounded px-1 py-0.5 text-xs font-bold leading-none {groupColor}">G{roundGroup}</span>
-										<!-- Undo -->
+										{#if !reassignMode}
 										<form method="POST" action="?/undoPick" use:enhance class="shrink-0">
 											<input type="hidden" name="pick_id" value={pick.id} />
 											<button type="submit" class="text-xs text-destructive/30 hover:text-destructive transition-colors">✕</button>
 										</form>
+										{/if}
 									</div>
 								{/each}
 							</div>
@@ -728,13 +811,14 @@
 
 	<!-- Toggle between live draft view and pick assignment view -->
 	{#if isLive && !draftComplete}
-		<div class="flex items-center gap-3">
+		<div class="flex items-center gap-2 flex-wrap">
 			<Button
 				variant={pickAssignMode ? 'default' : 'outline'}
 				size="sm"
-				onclick={() => (pickAssignMode = !pickAssignMode)}
+				class="h-7 text-xs"
+				onclick={() => { pickAssignMode = !pickAssignMode; reassignMode = false; }}
 			>
-				{pickAssignMode ? '← Back to Draft Board' : 'Assign Picks →'}
+				{pickAssignMode ? '← Back' : 'Assign Picks →'}
 			</Button>
 			{#if pickAssignMode}
 				<span class="text-xs text-muted-foreground">Drag an NCAA team onto a pool team's open slot to record the pick.</span>


### PR DESCRIPTION
## What

Adds pick reassignment to the Draft Log, accessible at any time — including after the draft is complete.

## Changes

**`src/routes/admin/+page.svelte`**
- "Reassign Picks →" button moved into the Draft Log card header, visible whenever picks exist (previously hidden behind `isLive && !draftComplete`)
- Pick rows become draggable in reassign mode (drag handle ⠿ appears)
- Pool team cards become drop targets with visual highlight on hover
- Dropping a pick onto a different team calls `?/reassignPick` and refreshes via `invalidateAll()`

**`src/routes/admin/+page.server.ts`**
- Added `reassignPick` action: updates `pool_team` and `user` on the pick record, resolving the correct user via `resolveUserId()`

**`scripts/update-ncaa-teams.cjs`**
- Script used to fix incorrect team/region data in PocketBase (Tennessee/Kentucky duplicate region issue)
