### PR TITLE
Leaderboard: card layout with team roster; add draft snapshot/restore…

### DIFF
--- a/scripts/draft-snapshot.json
+++ b/scripts/draft-snapshot.json
@@ -1,0 +1,1527 @@
+{
+  "snapshotAt": "2026-03-17T18:31:09.350Z",
+  "pool_teams": [
+    {
+      "collectionId": "pbc_2152491242",
+      "collectionName": "pool_teams",
+      "id": "73whg6hf2s0ofmt",
+      "name": "RFT & FRIENDS",
+      "slot_count": 2
+    },
+    {
+      "collectionId": "pbc_2152491242",
+      "collectionName": "pool_teams",
+      "id": "no3bqbjpf38941v",
+      "name": "TEAM GASTON",
+      "slot_count": 2
+    },
+    {
+      "collectionId": "pbc_2152491242",
+      "collectionName": "pool_teams",
+      "id": "8lbsjocexixpq4p",
+      "name": "STUTTS & MJ",
+      "slot_count": 2
+    },
+    {
+      "collectionId": "pbc_2152491242",
+      "collectionName": "pool_teams",
+      "id": "riioq662vl26xz7",
+      "name": "DDG (Debbie, Dolce & Garcia)",
+      "slot_count": 2
+    },
+    {
+      "collectionId": "pbc_2152491242",
+      "collectionName": "pool_teams",
+      "id": "e0i54qogkysx2u6",
+      "name": "TEAM HASSETT",
+      "slot_count": 2
+    },
+    {
+      "collectionId": "pbc_2152491242",
+      "collectionName": "pool_teams",
+      "id": "3mqopegilo4kyes",
+      "name": "MATT AND JOHN (The Apostles)",
+      "slot_count": 2
+    },
+    {
+      "collectionId": "pbc_2152491242",
+      "collectionName": "pool_teams",
+      "id": "874jxqqzavwx2pw",
+      "name": "MIKE SCOTT & JORGE'",
+      "slot_count": 1
+    },
+    {
+      "collectionId": "pbc_2152491242",
+      "collectionName": "pool_teams",
+      "id": "6uiwnwo6ksys3nh",
+      "name": "CHEF MIKE & SLOW PAY BARTLETT",
+      "slot_count": 1
+    },
+    {
+      "collectionId": "pbc_2152491242",
+      "collectionName": "pool_teams",
+      "id": "e8bcdh3u47zrtu8",
+      "name": "SQUIDCO AND LEECHES",
+      "slot_count": 1
+    },
+    {
+      "collectionId": "pbc_2152491242",
+      "collectionName": "pool_teams",
+      "id": "r9tslt05b0q6px1",
+      "name": "JK & DOAN",
+      "slot_count": 2
+    }
+  ],
+  "draft_orders": [
+    {
+      "collectionId": "pbc_425849653",
+      "collectionName": "draft_orders",
+      "id": "dsltwvz2j191c2z",
+      "pool_team": "73whg6hf2s0ofmt",
+      "position": 1,
+      "round_group": 1,
+      "user": ""
+    },
+    {
+      "collectionId": "pbc_425849653",
+      "collectionName": "draft_orders",
+      "id": "jzhe2u72x419xbx",
+      "pool_team": "no3bqbjpf38941v",
+      "position": 8,
+      "round_group": 1,
+      "user": ""
+    },
+    {
+      "collectionId": "pbc_425849653",
+      "collectionName": "draft_orders",
+      "id": "bfkbgdhtdmqs3f0",
+      "pool_team": "e8bcdh3u47zrtu8",
+      "position": 6,
+      "round_group": 1,
+      "user": ""
+    },
+    {
+      "collectionId": "pbc_425849653",
+      "collectionName": "draft_orders",
+      "id": "kz71oj264hxzmj0",
+      "pool_team": "874jxqqzavwx2pw",
+      "position": 2,
+      "round_group": 1,
+      "user": ""
+    },
+    {
+      "collectionId": "pbc_425849653",
+      "collectionName": "draft_orders",
+      "id": "bkaq6h4etnvzz3u",
+      "pool_team": "riioq662vl26xz7",
+      "position": 10,
+      "round_group": 1,
+      "user": ""
+    },
+    {
+      "collectionId": "pbc_425849653",
+      "collectionName": "draft_orders",
+      "id": "smhpo77q6bormb0",
+      "pool_team": "6uiwnwo6ksys3nh",
+      "position": 7,
+      "round_group": 1,
+      "user": ""
+    },
+    {
+      "collectionId": "pbc_425849653",
+      "collectionName": "draft_orders",
+      "id": "o9v6gznoz4vvt7b",
+      "pool_team": "3mqopegilo4kyes",
+      "position": 4,
+      "round_group": 1,
+      "user": ""
+    },
+    {
+      "collectionId": "pbc_425849653",
+      "collectionName": "draft_orders",
+      "id": "eft9izbb5f29gjr",
+      "pool_team": "r9tslt05b0q6px1",
+      "position": 5,
+      "round_group": 1,
+      "user": ""
+    },
+    {
+      "collectionId": "pbc_425849653",
+      "collectionName": "draft_orders",
+      "id": "wico8l4ndrtzprd",
+      "pool_team": "8lbsjocexixpq4p",
+      "position": 3,
+      "round_group": 1,
+      "user": ""
+    },
+    {
+      "collectionId": "pbc_425849653",
+      "collectionName": "draft_orders",
+      "id": "4lf01urjx619c5o",
+      "pool_team": "e0i54qogkysx2u6",
+      "position": 9,
+      "round_group": 1,
+      "user": ""
+    },
+    {
+      "collectionId": "pbc_425849653",
+      "collectionName": "draft_orders",
+      "id": "i5xvy0kr9xpv07w",
+      "pool_team": "riioq662vl26xz7",
+      "position": 2,
+      "round_group": 2,
+      "user": ""
+    },
+    {
+      "collectionId": "pbc_425849653",
+      "collectionName": "draft_orders",
+      "id": "po5c04byjn48ydy",
+      "pool_team": "874jxqqzavwx2pw",
+      "position": 5,
+      "round_group": 2,
+      "user": ""
+    },
+    {
+      "collectionId": "pbc_425849653",
+      "collectionName": "draft_orders",
+      "id": "131x1usru9bn53w",
+      "pool_team": "3mqopegilo4kyes",
+      "position": 4,
+      "round_group": 2,
+      "user": ""
+    },
+    {
+      "collectionId": "pbc_425849653",
+      "collectionName": "draft_orders",
+      "id": "xlz3erbns73t20i",
+      "pool_team": "6uiwnwo6ksys3nh",
+      "position": 1,
+      "round_group": 2,
+      "user": ""
+    },
+    {
+      "collectionId": "pbc_425849653",
+      "collectionName": "draft_orders",
+      "id": "jpzuhatpximbu1k",
+      "pool_team": "r9tslt05b0q6px1",
+      "position": 3,
+      "round_group": 2,
+      "user": ""
+    },
+    {
+      "collectionId": "pbc_425849653",
+      "collectionName": "draft_orders",
+      "id": "lsmobk51wyg332c",
+      "pool_team": "73whg6hf2s0ofmt",
+      "position": 6,
+      "round_group": 2,
+      "user": ""
+    },
+    {
+      "collectionId": "pbc_425849653",
+      "collectionName": "draft_orders",
+      "id": "uz406v5pbegbcde",
+      "pool_team": "no3bqbjpf38941v",
+      "position": 9,
+      "round_group": 2,
+      "user": ""
+    },
+    {
+      "collectionId": "pbc_425849653",
+      "collectionName": "draft_orders",
+      "id": "omiow89noo87zsl",
+      "pool_team": "e0i54qogkysx2u6",
+      "position": 10,
+      "round_group": 2,
+      "user": ""
+    },
+    {
+      "collectionId": "pbc_425849653",
+      "collectionName": "draft_orders",
+      "id": "xl4mrb940w6ooup",
+      "pool_team": "8lbsjocexixpq4p",
+      "position": 8,
+      "round_group": 2,
+      "user": ""
+    },
+    {
+      "collectionId": "pbc_425849653",
+      "collectionName": "draft_orders",
+      "id": "oxnzu7sl032iu4a",
+      "pool_team": "e8bcdh3u47zrtu8",
+      "position": 7,
+      "round_group": 2,
+      "user": ""
+    },
+    {
+      "collectionId": "pbc_425849653",
+      "collectionName": "draft_orders",
+      "id": "vmx2bol0rtsr7oz",
+      "pool_team": "riioq662vl26xz7",
+      "position": 2,
+      "round_group": 3,
+      "user": ""
+    },
+    {
+      "collectionId": "pbc_425849653",
+      "collectionName": "draft_orders",
+      "id": "t9sdkh1h6c6wcko",
+      "pool_team": "6uiwnwo6ksys3nh",
+      "position": 1,
+      "round_group": 3,
+      "user": ""
+    },
+    {
+      "collectionId": "pbc_425849653",
+      "collectionName": "draft_orders",
+      "id": "e5p4xkdhvokejdl",
+      "pool_team": "874jxqqzavwx2pw",
+      "position": 5,
+      "round_group": 3,
+      "user": ""
+    },
+    {
+      "collectionId": "pbc_425849653",
+      "collectionName": "draft_orders",
+      "id": "iemi4tr7hrd2hvk",
+      "pool_team": "r9tslt05b0q6px1",
+      "position": 3,
+      "round_group": 3,
+      "user": ""
+    },
+    {
+      "collectionId": "pbc_425849653",
+      "collectionName": "draft_orders",
+      "id": "tzzh48e3zhoms9f",
+      "pool_team": "3mqopegilo4kyes",
+      "position": 4,
+      "round_group": 3,
+      "user": ""
+    },
+    {
+      "collectionId": "pbc_425849653",
+      "collectionName": "draft_orders",
+      "id": "wsy1cogsa214nzx",
+      "pool_team": "e0i54qogkysx2u6",
+      "position": 10,
+      "round_group": 3,
+      "user": ""
+    },
+    {
+      "collectionId": "pbc_425849653",
+      "collectionName": "draft_orders",
+      "id": "ft9nbpa6jvlnenz",
+      "pool_team": "e8bcdh3u47zrtu8",
+      "position": 7,
+      "round_group": 3,
+      "user": ""
+    },
+    {
+      "collectionId": "pbc_425849653",
+      "collectionName": "draft_orders",
+      "id": "tqwnc15zgx3jwrh",
+      "pool_team": "no3bqbjpf38941v",
+      "position": 9,
+      "round_group": 3,
+      "user": ""
+    },
+    {
+      "collectionId": "pbc_425849653",
+      "collectionName": "draft_orders",
+      "id": "dlnn0tqzybug3hr",
+      "pool_team": "73whg6hf2s0ofmt",
+      "position": 6,
+      "round_group": 3,
+      "user": ""
+    },
+    {
+      "collectionId": "pbc_425849653",
+      "collectionName": "draft_orders",
+      "id": "qrjpvtt55xeq5fa",
+      "pool_team": "8lbsjocexixpq4p",
+      "position": 8,
+      "round_group": 3,
+      "user": ""
+    }
+  ],
+  "draft_picks": [
+    {
+      "collectionId": "pbc_2345463699",
+      "collectionName": "draft_picks",
+      "draft_round": 1,
+      "id": "euay2n9yvqse3be",
+      "pick_number": 1,
+      "pool_team": "73whg6hf2s0ofmt",
+      "team": "4ksmr54uxehwcns",
+      "user": "i6ftcczfjamaz16"
+    },
+    {
+      "collectionId": "pbc_2345463699",
+      "collectionName": "draft_picks",
+      "draft_round": 1,
+      "id": "8chsai68fg63wdr",
+      "pick_number": 2,
+      "pool_team": "874jxqqzavwx2pw",
+      "team": "hxkhvq0c4gsjm3w",
+      "user": "nk7q0xd859ztdn3"
+    },
+    {
+      "collectionId": "pbc_2345463699",
+      "collectionName": "draft_picks",
+      "draft_round": 1,
+      "id": "dcyqf5bqq6xng2r",
+      "pick_number": 3,
+      "pool_team": "8lbsjocexixpq4p",
+      "team": "ven9q1940a6iljx",
+      "user": "nk7q0xd859ztdn3"
+    },
+    {
+      "collectionId": "pbc_2345463699",
+      "collectionName": "draft_picks",
+      "draft_round": 1,
+      "id": "qntmhnp29mu7dn4",
+      "pick_number": 4,
+      "pool_team": "3mqopegilo4kyes",
+      "team": "gysuivqdxx0se63",
+      "user": "nk7q0xd859ztdn3"
+    },
+    {
+      "collectionId": "pbc_2345463699",
+      "collectionName": "draft_picks",
+      "draft_round": 1,
+      "id": "lp3o5zxkg2in8va",
+      "pick_number": 5,
+      "pool_team": "r9tslt05b0q6px1",
+      "team": "c6c0o5i3e2ksxpq",
+      "user": "nk7q0xd859ztdn3"
+    },
+    {
+      "collectionId": "pbc_2345463699",
+      "collectionName": "draft_picks",
+      "draft_round": 1,
+      "id": "mwgiiud5xjlrkq0",
+      "pick_number": 6,
+      "pool_team": "e8bcdh3u47zrtu8",
+      "team": "4yingisg1qnj2uv",
+      "user": "nk7q0xd859ztdn3"
+    },
+    {
+      "collectionId": "pbc_2345463699",
+      "collectionName": "draft_picks",
+      "draft_round": 1,
+      "id": "poz2aj65jknhpi1",
+      "pick_number": 7,
+      "pool_team": "6uiwnwo6ksys3nh",
+      "team": "myy8i1fqgiwfc3g",
+      "user": "nk7q0xd859ztdn3"
+    },
+    {
+      "collectionId": "pbc_2345463699",
+      "collectionName": "draft_picks",
+      "draft_round": 1,
+      "id": "6nvrekoc7t4xcgs",
+      "pick_number": 8,
+      "pool_team": "no3bqbjpf38941v",
+      "team": "o83ppcz71h1v89p",
+      "user": "nk7q0xd859ztdn3"
+    },
+    {
+      "collectionId": "pbc_2345463699",
+      "collectionName": "draft_picks",
+      "draft_round": 1,
+      "id": "jvj4b3tw9kpukn4",
+      "pick_number": 9,
+      "pool_team": "e0i54qogkysx2u6",
+      "team": "wmrk4cabols01l8",
+      "user": "kik9vccmjx37gqy"
+    },
+    {
+      "collectionId": "pbc_2345463699",
+      "collectionName": "draft_picks",
+      "draft_round": 1,
+      "id": "imz80ynnpz79g2u",
+      "pick_number": 10,
+      "pool_team": "riioq662vl26xz7",
+      "team": "ylns44m3b0g7z72",
+      "user": "nk7q0xd859ztdn3"
+    },
+    {
+      "collectionId": "pbc_2345463699",
+      "collectionName": "draft_picks",
+      "draft_round": 2,
+      "id": "2j2z9b1uqk5iftf",
+      "pick_number": 11,
+      "pool_team": "riioq662vl26xz7",
+      "team": "n7grf8ofdxnclkn",
+      "user": "nk7q0xd859ztdn3"
+    },
+    {
+      "collectionId": "pbc_2345463699",
+      "collectionName": "draft_picks",
+      "draft_round": 2,
+      "id": "sa9yp7y66ous1du",
+      "pick_number": 12,
+      "pool_team": "e0i54qogkysx2u6",
+      "team": "w590ok0yb9e1hmu",
+      "user": "kik9vccmjx37gqy"
+    },
+    {
+      "collectionId": "pbc_2345463699",
+      "collectionName": "draft_picks",
+      "draft_round": 2,
+      "id": "mpcownmfkbals3d",
+      "pick_number": 13,
+      "pool_team": "no3bqbjpf38941v",
+      "team": "rlbc41o0yzzz88m",
+      "user": "nk7q0xd859ztdn3"
+    },
+    {
+      "collectionId": "pbc_2345463699",
+      "collectionName": "draft_picks",
+      "draft_round": 2,
+      "id": "26i11z7f57g2mhr",
+      "pick_number": 14,
+      "pool_team": "6uiwnwo6ksys3nh",
+      "team": "oa90bvokfzg0gn5",
+      "user": "nk7q0xd859ztdn3"
+    },
+    {
+      "collectionId": "pbc_2345463699",
+      "collectionName": "draft_picks",
+      "draft_round": 2,
+      "id": "wqvpgh7ob21dysi",
+      "pick_number": 15,
+      "pool_team": "e8bcdh3u47zrtu8",
+      "team": "076a2tzdz9o64fr",
+      "user": "nk7q0xd859ztdn3"
+    },
+    {
+      "collectionId": "pbc_2345463699",
+      "collectionName": "draft_picks",
+      "draft_round": 2,
+      "id": "cgd6e80iqbyzxhg",
+      "pick_number": 16,
+      "pool_team": "r9tslt05b0q6px1",
+      "team": "i9br1f7p63wj10r",
+      "user": "nk7q0xd859ztdn3"
+    },
+    {
+      "collectionId": "pbc_2345463699",
+      "collectionName": "draft_picks",
+      "draft_round": 2,
+      "id": "4fgymqv7krwg3sh",
+      "pick_number": 17,
+      "pool_team": "3mqopegilo4kyes",
+      "team": "i3rsx5wz7tfs9i4",
+      "user": "nk7q0xd859ztdn3"
+    },
+    {
+      "collectionId": "pbc_2345463699",
+      "collectionName": "draft_picks",
+      "draft_round": 2,
+      "id": "ymvq736j1i03oze",
+      "pick_number": 18,
+      "pool_team": "8lbsjocexixpq4p",
+      "team": "w6sukxiypp5xer7",
+      "user": "nk7q0xd859ztdn3"
+    },
+    {
+      "collectionId": "pbc_2345463699",
+      "collectionName": "draft_picks",
+      "draft_round": 2,
+      "id": "y2ta1oht4y4n42u",
+      "pick_number": 19,
+      "pool_team": "874jxqqzavwx2pw",
+      "team": "a0wp1zso5zdibyk",
+      "user": "nk7q0xd859ztdn3"
+    },
+    {
+      "collectionId": "pbc_2345463699",
+      "collectionName": "draft_picks",
+      "draft_round": 2,
+      "id": "lzllnnmwbgl3iu0",
+      "pick_number": 20,
+      "pool_team": "73whg6hf2s0ofmt",
+      "team": "6mxfjcutazpwtrt",
+      "user": "i6ftcczfjamaz16"
+    },
+    {
+      "collectionId": "pbc_2345463699",
+      "collectionName": "draft_picks",
+      "draft_round": 3,
+      "id": "9qwhttwgf55dqvc",
+      "pick_number": 21,
+      "pool_team": "6uiwnwo6ksys3nh",
+      "team": "zgohn24edzcf1ry",
+      "user": "nk7q0xd859ztdn3"
+    },
+    {
+      "collectionId": "pbc_2345463699",
+      "collectionName": "draft_picks",
+      "draft_round": 3,
+      "id": "xg6pva7s49cvzvt",
+      "pick_number": 22,
+      "pool_team": "riioq662vl26xz7",
+      "team": "q6v3010y4adjsjh",
+      "user": "nk7q0xd859ztdn3"
+    },
+    {
+      "collectionId": "pbc_2345463699",
+      "collectionName": "draft_picks",
+      "draft_round": 3,
+      "id": "2c7hmmz5wioouoj",
+      "pick_number": 23,
+      "pool_team": "r9tslt05b0q6px1",
+      "team": "cg8crd8mji2sw5n",
+      "user": "nk7q0xd859ztdn3"
+    },
+    {
+      "collectionId": "pbc_2345463699",
+      "collectionName": "draft_picks",
+      "draft_round": 3,
+      "id": "unpot4pfcks1tbh",
+      "pick_number": 24,
+      "pool_team": "3mqopegilo4kyes",
+      "team": "n4mkosjrm6n9uqb",
+      "user": "nk7q0xd859ztdn3"
+    },
+    {
+      "collectionId": "pbc_2345463699",
+      "collectionName": "draft_picks",
+      "draft_round": 3,
+      "id": "vpmb6b83cd4txf8",
+      "pick_number": 25,
+      "pool_team": "874jxqqzavwx2pw",
+      "team": "01uppikpo64r8jw",
+      "user": "nk7q0xd859ztdn3"
+    },
+    {
+      "collectionId": "pbc_2345463699",
+      "collectionName": "draft_picks",
+      "draft_round": 3,
+      "id": "vo5rdctnya1zjlk",
+      "pick_number": 26,
+      "pool_team": "73whg6hf2s0ofmt",
+      "team": "02bq9xkayproodt",
+      "user": "i6ftcczfjamaz16"
+    },
+    {
+      "collectionId": "pbc_2345463699",
+      "collectionName": "draft_picks",
+      "draft_round": 3,
+      "id": "78kkvnmmmgxelpb",
+      "pick_number": 27,
+      "pool_team": "e8bcdh3u47zrtu8",
+      "team": "15qs07rfab85uyi",
+      "user": "nk7q0xd859ztdn3"
+    },
+    {
+      "collectionId": "pbc_2345463699",
+      "collectionName": "draft_picks",
+      "draft_round": 3,
+      "id": "ove5hjrpwddbr3f",
+      "pick_number": 28,
+      "pool_team": "8lbsjocexixpq4p",
+      "team": "gn9b5b7robpfcku",
+      "user": "nk7q0xd859ztdn3"
+    },
+    {
+      "collectionId": "pbc_2345463699",
+      "collectionName": "draft_picks",
+      "draft_round": 3,
+      "id": "m9afd5upnplw752",
+      "pick_number": 29,
+      "pool_team": "no3bqbjpf38941v",
+      "team": "7q3z6ag39uospnn",
+      "user": "nk7q0xd859ztdn3"
+    },
+    {
+      "collectionId": "pbc_2345463699",
+      "collectionName": "draft_picks",
+      "draft_round": 3,
+      "id": "egab9aubz1gizb2",
+      "pick_number": 30,
+      "pool_team": "e0i54qogkysx2u6",
+      "team": "txoftv96z4ihwxl",
+      "user": "kik9vccmjx37gqy"
+    },
+    {
+      "collectionId": "pbc_2345463699",
+      "collectionName": "draft_picks",
+      "draft_round": 4,
+      "id": "ftxqjj3zctslwwp",
+      "pick_number": 31,
+      "pool_team": "e0i54qogkysx2u6",
+      "team": "6v67zvckchgdhav",
+      "user": "kik9vccmjx37gqy"
+    },
+    {
+      "collectionId": "pbc_2345463699",
+      "collectionName": "draft_picks",
+      "draft_round": 4,
+      "id": "0va9brz97es91sy",
+      "pick_number": 32,
+      "pool_team": "no3bqbjpf38941v",
+      "team": "okusxagjfhua6r9",
+      "user": "nk7q0xd859ztdn3"
+    },
+    {
+      "collectionId": "pbc_2345463699",
+      "collectionName": "draft_picks",
+      "draft_round": 4,
+      "id": "7j6ruia4t7vvwev",
+      "pick_number": 33,
+      "pool_team": "8lbsjocexixpq4p",
+      "team": "elp31p2de45xs70",
+      "user": "nk7q0xd859ztdn3"
+    },
+    {
+      "collectionId": "pbc_2345463699",
+      "collectionName": "draft_picks",
+      "draft_round": 4,
+      "id": "zsfn1trtrq3s5zh",
+      "pick_number": 34,
+      "pool_team": "e8bcdh3u47zrtu8",
+      "team": "j055jwbr5q3trl6",
+      "user": "nk7q0xd859ztdn3"
+    },
+    {
+      "collectionId": "pbc_2345463699",
+      "collectionName": "draft_picks",
+      "draft_round": 4,
+      "id": "nuscn350s48t70c",
+      "pick_number": 35,
+      "pool_team": "73whg6hf2s0ofmt",
+      "team": "897482mjuo8cl5y",
+      "user": "i6ftcczfjamaz16"
+    },
+    {
+      "collectionId": "pbc_2345463699",
+      "collectionName": "draft_picks",
+      "draft_round": 4,
+      "id": "3x2qqlmegd94pns",
+      "pick_number": 36,
+      "pool_team": "874jxqqzavwx2pw",
+      "team": "7ax3054207780x2",
+      "user": "nk7q0xd859ztdn3"
+    },
+    {
+      "collectionId": "pbc_2345463699",
+      "collectionName": "draft_picks",
+      "draft_round": 4,
+      "id": "lk929t3cz7r9892",
+      "pick_number": 37,
+      "pool_team": "3mqopegilo4kyes",
+      "team": "261wh9ks6zrr5jd",
+      "user": "nk7q0xd859ztdn3"
+    },
+    {
+      "collectionId": "pbc_2345463699",
+      "collectionName": "draft_picks",
+      "draft_round": 4,
+      "id": "28bykv4k48qnbfv",
+      "pick_number": 38,
+      "pool_team": "r9tslt05b0q6px1",
+      "team": "8a5g27veljuzxv2",
+      "user": "nk7q0xd859ztdn3"
+    },
+    {
+      "collectionId": "pbc_2345463699",
+      "collectionName": "draft_picks",
+      "draft_round": 4,
+      "id": "984d3u7vsh0lrkb",
+      "pick_number": 39,
+      "pool_team": "riioq662vl26xz7",
+      "team": "qk0fk1cgv44xfgq",
+      "user": "nk7q0xd859ztdn3"
+    },
+    {
+      "collectionId": "pbc_2345463699",
+      "collectionName": "draft_picks",
+      "draft_round": 4,
+      "id": "wcnb3l9wtn2zhil",
+      "pick_number": 40,
+      "pool_team": "6uiwnwo6ksys3nh",
+      "team": "22vhtmnvtg7sfgt",
+      "user": "nk7q0xd859ztdn3"
+    },
+    {
+      "collectionId": "pbc_2345463699",
+      "collectionName": "draft_picks",
+      "draft_round": 5,
+      "id": "wl5t0sigc6ef6dk",
+      "pick_number": 41,
+      "pool_team": "riioq662vl26xz7",
+      "team": "cv36tyuacujj18m",
+      "user": "nk7q0xd859ztdn3"
+    },
+    {
+      "collectionId": "pbc_2345463699",
+      "collectionName": "draft_picks",
+      "draft_round": 5,
+      "id": "f0q9o0wedklbbkj",
+      "pick_number": 42,
+      "pool_team": "no3bqbjpf38941v",
+      "team": "aw3z0mt9w0sczmv",
+      "user": "nk7q0xd859ztdn3"
+    },
+    {
+      "collectionId": "pbc_2345463699",
+      "collectionName": "draft_picks",
+      "draft_round": 5,
+      "id": "j8mcoy67qaxg01k",
+      "pick_number": 43,
+      "pool_team": "e8bcdh3u47zrtu8",
+      "team": "wxh8e8ka6mnk9yd",
+      "user": "nk7q0xd859ztdn3"
+    },
+    {
+      "collectionId": "pbc_2345463699",
+      "collectionName": "draft_picks",
+      "draft_round": 5,
+      "id": "1wx17at0f9ratnm",
+      "pick_number": 44,
+      "pool_team": "874jxqqzavwx2pw",
+      "team": "yzsa1rvmd0h7ver",
+      "user": "nk7q0xd859ztdn3"
+    },
+    {
+      "collectionId": "pbc_2345463699",
+      "collectionName": "draft_picks",
+      "draft_round": 5,
+      "id": "bswzlr4fif28x2f",
+      "pick_number": 45,
+      "pool_team": "6uiwnwo6ksys3nh",
+      "team": "m6e0myghiif2v4l",
+      "user": "nk7q0xd859ztdn3"
+    },
+    {
+      "collectionId": "pbc_2345463699",
+      "collectionName": "draft_picks",
+      "draft_round": 5,
+      "id": "8qfl8ad2brfaevi",
+      "pick_number": 46,
+      "pool_team": "73whg6hf2s0ofmt",
+      "team": "merjx72dwby79kv",
+      "user": "i6ftcczfjamaz16"
+    },
+    {
+      "collectionId": "pbc_2345463699",
+      "collectionName": "draft_picks",
+      "draft_round": 5,
+      "id": "exwzqjznjyuohwp",
+      "pick_number": 47,
+      "pool_team": "r9tslt05b0q6px1",
+      "team": "fw3ek5tek3y2sik",
+      "user": "nk7q0xd859ztdn3"
+    },
+    {
+      "collectionId": "pbc_2345463699",
+      "collectionName": "draft_picks",
+      "draft_round": 5,
+      "id": "bqa69zobpv6mnxa",
+      "pick_number": 48,
+      "pool_team": "e0i54qogkysx2u6",
+      "team": "rsj20vftsqnofnl",
+      "user": "kik9vccmjx37gqy"
+    },
+    {
+      "collectionId": "pbc_2345463699",
+      "collectionName": "draft_picks",
+      "draft_round": 5,
+      "id": "afosm1f8h5fv6mj",
+      "pick_number": 49,
+      "pool_team": "e0i54qogkysx2u6",
+      "team": "28kz1kuji31qoxo",
+      "user": "kik9vccmjx37gqy"
+    },
+    {
+      "collectionId": "pbc_2345463699",
+      "collectionName": "draft_picks",
+      "draft_round": 5,
+      "id": "lo80poi08kft0rh",
+      "pick_number": 50,
+      "pool_team": "r9tslt05b0q6px1",
+      "team": "a12c0p9y7h5ma0j",
+      "user": "nk7q0xd859ztdn3"
+    },
+    {
+      "collectionId": "pbc_2345463699",
+      "collectionName": "draft_picks",
+      "draft_round": 6,
+      "id": "yzq0w25q38uj9h5",
+      "pick_number": 51,
+      "pool_team": "8lbsjocexixpq4p",
+      "team": "1u66l8kz29y3rit",
+      "user": "nk7q0xd859ztdn3"
+    },
+    {
+      "collectionId": "pbc_2345463699",
+      "collectionName": "draft_picks",
+      "draft_round": 6,
+      "id": "jp5s7q9kpwm3lku",
+      "pick_number": 52,
+      "pool_team": "no3bqbjpf38941v",
+      "team": "zxxm29pthwf54hf",
+      "user": "nk7q0xd859ztdn3"
+    },
+    {
+      "collectionId": "pbc_2345463699",
+      "collectionName": "draft_picks",
+      "draft_round": 6,
+      "id": "7ejmcevpnthz3wy",
+      "pick_number": 53,
+      "pool_team": "6uiwnwo6ksys3nh",
+      "team": "emiwfu7wu6h7lz3",
+      "user": "nk7q0xd859ztdn3"
+    },
+    {
+      "collectionId": "pbc_2345463699",
+      "collectionName": "draft_picks",
+      "draft_round": 6,
+      "id": "c9dembn5y5447a9",
+      "pick_number": 54,
+      "pool_team": "e8bcdh3u47zrtu8",
+      "team": "5kxy4x8fqz9pqc5",
+      "user": "nk7q0xd859ztdn3"
+    },
+    {
+      "collectionId": "pbc_2345463699",
+      "collectionName": "draft_picks",
+      "draft_round": 6,
+      "id": "8yhlztvfq6yxfiy",
+      "pick_number": 55,
+      "pool_team": "3mqopegilo4kyes",
+      "team": "xjoef060bp8td54",
+      "user": "nk7q0xd859ztdn3"
+    },
+    {
+      "collectionId": "pbc_2345463699",
+      "collectionName": "draft_picks",
+      "draft_round": 6,
+      "id": "dxgw4wdqgz3be04",
+      "pick_number": 56,
+      "pool_team": "73whg6hf2s0ofmt",
+      "team": "gc2z2922a5tkt8a",
+      "user": "i6ftcczfjamaz16"
+    },
+    {
+      "collectionId": "pbc_2345463699",
+      "collectionName": "draft_picks",
+      "draft_round": 6,
+      "id": "msd3rlbja75klgp",
+      "pick_number": 57,
+      "pool_team": "3mqopegilo4kyes",
+      "team": "s366ogcsgmqnwq4",
+      "user": "nk7q0xd859ztdn3"
+    },
+    {
+      "collectionId": "pbc_2345463699",
+      "collectionName": "draft_picks",
+      "draft_round": 6,
+      "id": "ormt4z9teu1be6j",
+      "pick_number": 58,
+      "pool_team": "riioq662vl26xz7",
+      "team": "1aijbrxqtpvi1ks",
+      "user": "nk7q0xd859ztdn3"
+    },
+    {
+      "collectionId": "pbc_2345463699",
+      "collectionName": "draft_picks",
+      "draft_round": 6,
+      "id": "shgqkr73ye6efpa",
+      "pick_number": 60,
+      "pool_team": "8lbsjocexixpq4p",
+      "team": "uh9ctrfznn0dume",
+      "user": "nk7q0xd859ztdn3"
+    },
+    {
+      "collectionId": "pbc_2345463699",
+      "collectionName": "draft_picks",
+      "draft_round": 6,
+      "id": "n361ajpphjqrwa2",
+      "pick_number": 60,
+      "pool_team": "874jxqqzavwx2pw",
+      "team": "0h78b1zgkk1c44l",
+      "user": "nk7q0xd859ztdn3"
+    }
+  ],
+  "ncaa_teams": [
+    {
+      "collectionId": "pbc_725768535",
+      "collectionName": "ncaa_teams",
+      "eliminated_round": "",
+      "id": "gysuivqdxx0se63",
+      "name": "Florida Gators",
+      "region": "South",
+      "seed": 1
+    },
+    {
+      "collectionId": "pbc_725768535",
+      "collectionName": "ncaa_teams",
+      "eliminated_round": "",
+      "id": "hxkhvq0c4gsjm3w",
+      "name": "Arizona Wildcats",
+      "region": "West",
+      "seed": 1
+    },
+    {
+      "collectionId": "pbc_725768535",
+      "collectionName": "ncaa_teams",
+      "eliminated_round": "",
+      "id": "4ksmr54uxehwcns",
+      "name": "Duke Blue Devils",
+      "region": "East",
+      "seed": 1
+    },
+    {
+      "collectionId": "pbc_725768535",
+      "collectionName": "ncaa_teams",
+      "eliminated_round": "",
+      "id": "ven9q1940a6iljx",
+      "name": "Michigan Wolverines",
+      "region": "Midwest",
+      "seed": 1
+    },
+    {
+      "collectionId": "pbc_725768535",
+      "collectionName": "ncaa_teams",
+      "eliminated_round": "",
+      "id": "n7grf8ofdxnclkn",
+      "name": "Purdue Boilermakers",
+      "region": "West",
+      "seed": 2
+    },
+    {
+      "collectionId": "pbc_725768535",
+      "collectionName": "ncaa_teams",
+      "eliminated_round": "",
+      "id": "c6c0o5i3e2ksxpq",
+      "name": "Houston Cougars",
+      "region": "South",
+      "seed": 2
+    },
+    {
+      "collectionId": "pbc_725768535",
+      "collectionName": "ncaa_teams",
+      "eliminated_round": "",
+      "id": "4yingisg1qnj2uv",
+      "name": "UConn Huskies",
+      "region": "East",
+      "seed": 2
+    },
+    {
+      "collectionId": "pbc_725768535",
+      "collectionName": "ncaa_teams",
+      "eliminated_round": "",
+      "id": "myy8i1fqgiwfc3g",
+      "name": "Iowa State Cyclones",
+      "region": "Midwest",
+      "seed": 2
+    },
+    {
+      "collectionId": "pbc_725768535",
+      "collectionName": "ncaa_teams",
+      "eliminated_round": "",
+      "id": "i9br1f7p63wj10r",
+      "name": "Alabama Crimson Tide",
+      "region": "Midwest",
+      "seed": 4
+    },
+    {
+      "collectionId": "pbc_725768535",
+      "collectionName": "ncaa_teams",
+      "eliminated_round": "",
+      "id": "o83ppcz71h1v89p",
+      "name": "Michigan State Spartans",
+      "region": "East",
+      "seed": 3
+    },
+    {
+      "collectionId": "pbc_725768535",
+      "collectionName": "ncaa_teams",
+      "eliminated_round": "",
+      "id": "rlbc41o0yzzz88m",
+      "name": "Kansas Jayhawks",
+      "region": "East",
+      "seed": 4
+    },
+    {
+      "collectionId": "pbc_725768535",
+      "collectionName": "ncaa_teams",
+      "eliminated_round": "",
+      "id": "ylns44m3b0g7z72",
+      "name": "Illinois Fighting Illini",
+      "region": "South",
+      "seed": 3
+    },
+    {
+      "collectionId": "pbc_725768535",
+      "collectionName": "ncaa_teams",
+      "eliminated_round": "",
+      "id": "i3rsx5wz7tfs9i4",
+      "name": "Nebraska Cornhuskers",
+      "region": "South",
+      "seed": 4
+    },
+    {
+      "collectionId": "pbc_725768535",
+      "collectionName": "ncaa_teams",
+      "eliminated_round": "",
+      "id": "w590ok0yb9e1hmu",
+      "name": "Virginia Cavaliers",
+      "region": "Midwest",
+      "seed": 3
+    },
+    {
+      "collectionId": "pbc_725768535",
+      "collectionName": "ncaa_teams",
+      "eliminated_round": "",
+      "id": "076a2tzdz9o64fr",
+      "name": "Arkansas Razorbacks",
+      "region": "West",
+      "seed": 4
+    },
+    {
+      "collectionId": "pbc_725768535",
+      "collectionName": "ncaa_teams",
+      "eliminated_round": "",
+      "id": "wmrk4cabols01l8",
+      "name": "Gonzaga Bulldogs",
+      "region": "West",
+      "seed": 3
+    },
+    {
+      "collectionId": "pbc_725768535",
+      "collectionName": "ncaa_teams",
+      "eliminated_round": "",
+      "id": "n4mkosjrm6n9uqb",
+      "name": "Texas Tech Red Raiders",
+      "region": "Midwest",
+      "seed": 5
+    },
+    {
+      "collectionId": "pbc_725768535",
+      "collectionName": "ncaa_teams",
+      "eliminated_round": "",
+      "id": "15qs07rfab85uyi",
+      "name": "North Carolina Tar Heels",
+      "region": "South",
+      "seed": 6
+    },
+    {
+      "collectionId": "pbc_725768535",
+      "collectionName": "ncaa_teams",
+      "eliminated_round": "",
+      "id": "w6sukxiypp5xer7",
+      "name": "Wisconsin Badgers",
+      "region": "West",
+      "seed": 5
+    },
+    {
+      "collectionId": "pbc_725768535",
+      "collectionName": "ncaa_teams",
+      "eliminated_round": "",
+      "id": "02bq9xkayproodt",
+      "name": "Tennessee Volunteers",
+      "region": "Midwest",
+      "seed": 6
+    },
+    {
+      "collectionId": "pbc_725768535",
+      "collectionName": "ncaa_teams",
+      "eliminated_round": "",
+      "id": "oa90bvokfzg0gn5",
+      "name": "St. John's Red Storm",
+      "region": "East",
+      "seed": 5
+    },
+    {
+      "collectionId": "pbc_725768535",
+      "collectionName": "ncaa_teams",
+      "eliminated_round": "",
+      "id": "6mxfjcutazpwtrt",
+      "name": "Louisville Cardinals",
+      "region": "East",
+      "seed": 6
+    },
+    {
+      "collectionId": "pbc_725768535",
+      "collectionName": "ncaa_teams",
+      "eliminated_round": "",
+      "id": "cg8crd8mji2sw5n",
+      "name": "BYU Cougars",
+      "region": "West",
+      "seed": 6
+    },
+    {
+      "collectionId": "pbc_725768535",
+      "collectionName": "ncaa_teams",
+      "eliminated_round": "",
+      "id": "a0wp1zso5zdibyk",
+      "name": "Vanderbilt Commodores",
+      "region": "South",
+      "seed": 5
+    },
+    {
+      "collectionId": "pbc_725768535",
+      "collectionName": "ncaa_teams",
+      "eliminated_round": "",
+      "id": "elp31p2de45xs70",
+      "name": "Clemson Tigers",
+      "region": "South",
+      "seed": 8
+    },
+    {
+      "collectionId": "pbc_725768535",
+      "collectionName": "ncaa_teams",
+      "eliminated_round": "",
+      "id": "6v67zvckchgdhav",
+      "name": "Georgia Bulldogs",
+      "region": "Midwest",
+      "seed": 8
+    },
+    {
+      "collectionId": "pbc_725768535",
+      "collectionName": "ncaa_teams",
+      "eliminated_round": "",
+      "id": "txoftv96z4ihwxl",
+      "name": "Villanova Wildcats",
+      "region": "West",
+      "seed": 8
+    },
+    {
+      "collectionId": "pbc_725768535",
+      "collectionName": "ncaa_teams",
+      "eliminated_round": "",
+      "id": "gn9b5b7robpfcku",
+      "name": "Saint Mary's Gaels",
+      "region": "South",
+      "seed": 7
+    },
+    {
+      "collectionId": "pbc_725768535",
+      "collectionName": "ncaa_teams",
+      "eliminated_round": "",
+      "id": "okusxagjfhua6r9",
+      "name": "Kentucky Wildcats",
+      "region": "Midwest",
+      "seed": 7
+    },
+    {
+      "collectionId": "pbc_725768535",
+      "collectionName": "ncaa_teams",
+      "eliminated_round": "",
+      "id": "zgohn24edzcf1ry",
+      "name": "UCLA Bruins",
+      "region": "East",
+      "seed": 7
+    },
+    {
+      "collectionId": "pbc_725768535",
+      "collectionName": "ncaa_teams",
+      "eliminated_round": "",
+      "id": "7q3z6ag39uospnn",
+      "name": "Ohio State Buckeyes",
+      "region": "East",
+      "seed": 8
+    },
+    {
+      "collectionId": "pbc_725768535",
+      "collectionName": "ncaa_teams",
+      "eliminated_round": "",
+      "id": "q6v3010y4adjsjh",
+      "name": "Miami Hurricanes",
+      "region": "West",
+      "seed": 7
+    },
+    {
+      "collectionId": "pbc_725768535",
+      "collectionName": "ncaa_teams",
+      "eliminated_round": "",
+      "id": "261wh9ks6zrr5jd",
+      "name": "Texas A&M Aggies",
+      "region": "South",
+      "seed": 10
+    },
+    {
+      "collectionId": "pbc_725768535",
+      "collectionName": "ncaa_teams",
+      "eliminated_round": "",
+      "id": "01uppikpo64r8jw",
+      "name": "TCU Horned Frogs",
+      "region": "East",
+      "seed": 9
+    },
+    {
+      "collectionId": "pbc_725768535",
+      "collectionName": "ncaa_teams",
+      "eliminated_round": "",
+      "id": "j055jwbr5q3trl6",
+      "name": "Saint Louis Billikens",
+      "region": "Midwest",
+      "seed": 9
+    },
+    {
+      "collectionId": "pbc_725768535",
+      "collectionName": "ncaa_teams",
+      "eliminated_round": "",
+      "id": "merjx72dwby79kv",
+      "name": "Utah State Aggies",
+      "region": "West",
+      "seed": 9
+    },
+    {
+      "collectionId": "pbc_725768535",
+      "collectionName": "ncaa_teams",
+      "eliminated_round": "",
+      "id": "897482mjuo8cl5y",
+      "name": "Iowa Hawkeyes",
+      "region": "South",
+      "seed": 9
+    },
+    {
+      "collectionId": "pbc_725768535",
+      "collectionName": "ncaa_teams",
+      "eliminated_round": "",
+      "id": "7ax3054207780x2",
+      "name": "UCF Knights",
+      "region": "East",
+      "seed": 10
+    },
+    {
+      "collectionId": "pbc_725768535",
+      "collectionName": "ncaa_teams",
+      "eliminated_round": "",
+      "id": "qk0fk1cgv44xfgq",
+      "name": "Santa Clara Broncos",
+      "region": "Midwest",
+      "seed": 10
+    },
+    {
+      "collectionId": "pbc_725768535",
+      "collectionName": "ncaa_teams",
+      "eliminated_round": "",
+      "id": "fw3ek5tek3y2sik",
+      "name": "Missouri Tigers",
+      "region": "West",
+      "seed": 10
+    },
+    {
+      "collectionId": "pbc_725768535",
+      "collectionName": "ncaa_teams",
+      "eliminated_round": "",
+      "id": "28kz1kuji31qoxo",
+      "name": "High Point Panthers",
+      "region": "West",
+      "seed": 12
+    },
+    {
+      "collectionId": "pbc_725768535",
+      "collectionName": "ncaa_teams",
+      "eliminated_round": "",
+      "id": "22vhtmnvtg7sfgt",
+      "name": "Akron Zips",
+      "region": "Midwest",
+      "seed": 12
+    },
+    {
+      "collectionId": "pbc_725768535",
+      "collectionName": "ncaa_teams",
+      "eliminated_round": "",
+      "id": "m6e0myghiif2v4l",
+      "name": "NC State",
+      "region": "West",
+      "seed": 11
+    },
+    {
+      "collectionId": "pbc_725768535",
+      "collectionName": "ncaa_teams",
+      "eliminated_round": "",
+      "id": "8a5g27veljuzxv2",
+      "name": "VCU Rams",
+      "region": "South",
+      "seed": 11
+    },
+    {
+      "collectionId": "pbc_725768535",
+      "collectionName": "ncaa_teams",
+      "eliminated_round": "",
+      "id": "aw3z0mt9w0sczmv",
+      "name": "McNeese Cowboys",
+      "region": "South",
+      "seed": 12
+    },
+    {
+      "collectionId": "pbc_725768535",
+      "collectionName": "ncaa_teams",
+      "eliminated_round": "",
+      "id": "wxh8e8ka6mnk9yd",
+      "name": "Northern Iowa Panthers",
+      "region": "East",
+      "seed": 12
+    },
+    {
+      "collectionId": "pbc_725768535",
+      "collectionName": "ncaa_teams",
+      "eliminated_round": "",
+      "id": "rsj20vftsqnofnl",
+      "name": "Miami (OH)",
+      "region": "Midwest",
+      "seed": 11
+    },
+    {
+      "collectionId": "pbc_725768535",
+      "collectionName": "ncaa_teams",
+      "eliminated_round": "",
+      "id": "cv36tyuacujj18m",
+      "name": "South Florida Bulls",
+      "region": "East",
+      "seed": 11
+    },
+    {
+      "collectionId": "pbc_725768535",
+      "collectionName": "ncaa_teams",
+      "eliminated_round": "",
+      "id": "xjoef060bp8td54",
+      "name": "Hofstra Pride",
+      "region": "Midwest",
+      "seed": 13
+    },
+    {
+      "collectionId": "pbc_725768535",
+      "collectionName": "ncaa_teams",
+      "eliminated_round": "",
+      "id": "gc2z2922a5tkt8a",
+      "name": "Wright State Raiders",
+      "region": "Midwest",
+      "seed": 14
+    },
+    {
+      "collectionId": "pbc_725768535",
+      "collectionName": "ncaa_teams",
+      "eliminated_round": "",
+      "id": "zxxm29pthwf54hf",
+      "name": "Hawaii Rainbow Warriors",
+      "region": "West",
+      "seed": 13
+    },
+    {
+      "collectionId": "pbc_725768535",
+      "collectionName": "ncaa_teams",
+      "eliminated_round": "",
+      "id": "yzsa1rvmd0h7ver",
+      "name": "Troy Trojans",
+      "region": "South",
+      "seed": 13
+    },
+    {
+      "collectionId": "pbc_725768535",
+      "collectionName": "ncaa_teams",
+      "eliminated_round": "",
+      "id": "emiwfu7wu6h7lz3",
+      "name": "Kennesaw State Owls",
+      "region": "West",
+      "seed": 14
+    },
+    {
+      "collectionId": "pbc_725768535",
+      "collectionName": "ncaa_teams",
+      "eliminated_round": "",
+      "id": "5kxy4x8fqz9pqc5",
+      "name": "Penn Quakers",
+      "region": "South",
+      "seed": 14
+    },
+    {
+      "collectionId": "pbc_725768535",
+      "collectionName": "ncaa_teams",
+      "eliminated_round": "",
+      "id": "1u66l8kz29y3rit",
+      "name": "Cal Baptist Lancers",
+      "region": "East",
+      "seed": 13
+    },
+    {
+      "collectionId": "pbc_725768535",
+      "collectionName": "ncaa_teams",
+      "eliminated_round": "",
+      "id": "a12c0p9y7h5ma0j",
+      "name": "North Dakota State Bison",
+      "region": "East",
+      "seed": 14
+    },
+    {
+      "collectionId": "pbc_725768535",
+      "collectionName": "ncaa_teams",
+      "eliminated_round": "",
+      "id": "1aijbrxqtpvi1ks",
+      "name": "Idaho Vandals",
+      "region": "South",
+      "seed": 15
+    },
+    {
+      "collectionId": "pbc_725768535",
+      "collectionName": "ncaa_teams",
+      "eliminated_round": "",
+      "id": "0h78b1zgkk1c44l",
+      "name": "Howard",
+      "region": "Midwest",
+      "seed": 16
+    },
+    {
+      "collectionId": "pbc_725768535",
+      "collectionName": "ncaa_teams",
+      "eliminated_round": "",
+      "id": "s366ogcsgmqnwq4",
+      "name": "Texas",
+      "region": "First Four 2",
+      "seed": 11
+    },
+    {
+      "collectionId": "pbc_725768535",
+      "collectionName": "ncaa_teams",
+      "eliminated_round": "",
+      "id": "pzsr8mo6fkz4flt",
+      "name": "Queens Royals",
+      "region": "West",
+      "seed": 15
+    },
+    {
+      "collectionId": "pbc_725768535",
+      "collectionName": "ncaa_teams",
+      "eliminated_round": "",
+      "id": "uwx4kvgd5pfyyjk",
+      "name": "Prairie View / Lehigh",
+      "region": "South",
+      "seed": 16
+    },
+    {
+      "collectionId": "pbc_725768535",
+      "collectionName": "ncaa_teams",
+      "eliminated_round": "",
+      "id": "9dlsrb4vosoqgi6",
+      "name": "LIU Sharks",
+      "region": "West",
+      "seed": 16
+    },
+    {
+      "collectionId": "pbc_725768535",
+      "collectionName": "ncaa_teams",
+      "eliminated_round": "",
+      "id": "uh9ctrfznn0dume",
+      "name": "SMU",
+      "region": "First Four",
+      "seed": 11
+    },
+    {
+      "collectionId": "pbc_725768535",
+      "collectionName": "ncaa_teams",
+      "eliminated_round": "",
+      "id": "0cap4362xbcv270",
+      "name": "Siena Saints",
+      "region": "East",
+      "seed": 16
+    }
+  ]
+}

--- a/scripts/restore-draft.cjs
+++ b/scripts/restore-draft.cjs
@@ -1,0 +1,148 @@
+#!/usr/bin/env node
+/**
+ * Restores pool_teams, draft_orders, and draft_picks from scripts/draft-snapshot.json.
+ * Clears existing records first, then re-creates from snapshot.
+ * ncaa_teams are matched by name — not deleted/recreated.
+ *
+ * Usage: node scripts/restore-draft.cjs
+ */
+const https = require('https');
+const http = require('http');
+const fs = require('fs');
+const path = require('path');
+
+const envPath = path.join(__dirname, '../.env');
+const envVars = {};
+if (fs.existsSync(envPath)) {
+  fs.readFileSync(envPath, 'utf8').split('\n').forEach(line => {
+    const m = line.match(/^([^#=]+)=(.*)/);
+    if (m) envVars[m[1].trim()] = m[2].trim().replace(/^['"]|['"]$/g, '');
+  });
+}
+const BASE_URL = (envVars.POCKETBASE_URL || process.env.POCKETBASE_URL || '').replace(/\/$/, '');
+const EMAIL = envVars.POCKETBASE_ADMIN_EMAIL || process.env.POCKETBASE_ADMIN_EMAIL;
+const PASSWORD = envVars.POCKETBASE_ADMIN_PASSWORD || process.env.POCKETBASE_ADMIN_PASSWORD;
+
+let TOKEN = '';
+
+function httpReq(method, urlStr, body) {
+  return new Promise((resolve, reject) => {
+    const parsed = new URL(urlStr);
+    const lib = parsed.protocol === 'https:' ? https : http;
+    const data = body ? JSON.stringify(body) : null;
+    const headers = { 'Content-Type': 'application/json' };
+    if (TOKEN) headers['Authorization'] = 'Bearer ' + TOKEN;
+    if (data) headers['Content-Length'] = Buffer.byteLength(data);
+    const req = lib.request({
+      hostname: parsed.hostname,
+      port: parsed.port || (parsed.protocol === 'https:' ? 443 : 80),
+      path: parsed.pathname + parsed.search,
+      method, headers
+    }, (res) => {
+      let raw = '';
+      res.on('data', d => raw += d);
+      res.on('end', () => { try { resolve({ status: res.statusCode, body: JSON.parse(raw) }); } catch { resolve({ status: res.statusCode, body: raw }); } });
+    });
+    req.on('error', reject);
+    if (data) req.write(data);
+    req.end();
+  });
+}
+
+async function getAll(collection) {
+  let page = 1, items = [];
+  while (true) {
+    const r = await httpReq('GET', BASE_URL + '/api/collections/' + collection + '/records?page=' + page + '&perPage=200');
+    if (!r.body.items) break;
+    items = items.concat(r.body.items);
+    if (page >= (r.body.totalPages || 1)) break;
+    page++;
+  }
+  return items;
+}
+
+async function deleteAll(collection) {
+  const items = await getAll(collection);
+  for (const item of items) {
+    await httpReq('DELETE', BASE_URL + '/api/collections/' + collection + '/records/' + item.id);
+  }
+  console.log('  Deleted ' + items.length + ' records from ' + collection);
+}
+
+async function main() {
+  const snapshotPath = path.join(__dirname, 'draft-snapshot.json');
+  if (!fs.existsSync(snapshotPath)) { console.error('No snapshot found. Run snapshot-draft.cjs first.'); process.exit(1); }
+  const snapshot = JSON.parse(fs.readFileSync(snapshotPath, 'utf8'));
+  console.log('Restoring snapshot from ' + snapshot.snapshotAt);
+
+  // Auth
+  const authRes = await new Promise((resolve, reject) => {
+    const url = new URL(BASE_URL + '/api/collections/_superusers/auth-with-password');
+    const lib = url.protocol === 'https:' ? https : http;
+    const data = JSON.stringify({ identity: EMAIL, password: PASSWORD });
+    const req = lib.request({ hostname: url.hostname, port: url.port || (url.protocol === 'https:' ? 443 : 80), path: url.pathname, method: 'POST', headers: { 'Content-Type': 'application/json', 'Content-Length': Buffer.byteLength(data) } }, res => {
+      let raw = ''; res.on('data', d => raw += d); res.on('end', () => { try { resolve(JSON.parse(raw)); } catch { resolve({}); } });
+    });
+    req.on('error', reject); req.write(data); req.end();
+  });
+  TOKEN = authRes.token;
+  if (!TOKEN) { console.error('Auth failed', authRes); process.exit(1); }
+
+  // Build ncaa_teams name->id map from live DB
+  const liveNcaaTeams = await getAll('ncaa_teams');
+  const ncaaByName = {};
+  for (const t of liveNcaaTeams) ncaaByName[t.name] = t.id;
+
+  // Build snapshot ncaa_teams id->name map
+  const snapNcaaById = {};
+  for (const t of snapshot.ncaa_teams) snapNcaaById[t.id] = t.name;
+
+  // 1. Clear in dependency order
+  console.log('\nClearing existing records...');
+  await deleteAll('draft_picks');
+  await deleteAll('draft_orders');
+  await deleteAll('pool_teams');
+
+  // 2. Restore pool_teams, build old->new id map
+  console.log('\nRestoring pool_teams...');
+  const poolTeamIdMap = {};
+  for (const pt of snapshot.pool_teams) {
+    const r = await httpReq('POST', BASE_URL + '/api/collections/pool_teams/records', { name: pt.name, slot_count: pt.slot_count ?? 1 });
+    if (r.status !== 200) { console.error('  Failed pool_team', pt.name, r.body); continue; }
+    poolTeamIdMap[pt.id] = r.body.id;
+    console.log('  ' + pt.name + ' -> ' + r.body.id);
+  }
+
+  // 3. Restore draft_orders
+  console.log('\nRestoring draft_orders...');
+  let orderOk = 0;
+  for (const o of snapshot.draft_orders) {
+    const newPoolTeamId = poolTeamIdMap[o.pool_team];
+    if (!newPoolTeamId) { console.warn('  Skipping order — no pool_team mapping for ' + o.pool_team); continue; }
+    const r = await httpReq('POST', BASE_URL + '/api/collections/draft_orders/records', { pool_team: newPoolTeamId, position: o.position, round_group: o.round_group });
+    if (r.status !== 200) console.error('  Failed draft_order', r.body);
+    else orderOk++;
+  }
+  console.log('  Restored ' + orderOk + '/' + snapshot.draft_orders.length + ' draft_orders');
+
+  // 4. Restore draft_picks
+  console.log('\nRestoring draft_picks...');
+  let pickOk = 0, pickFail = 0;
+  // Sort by pick_number to preserve order
+  const sortedPicks = [...snapshot.draft_picks].sort((a, b) => a.pick_number - b.pick_number);
+  for (const p of sortedPicks) {
+    const newPoolTeamId = poolTeamIdMap[p.pool_team];
+    if (!newPoolTeamId) { console.warn('  Skipping pick — no pool_team mapping for ' + p.pool_team); pickFail++; continue; }
+    const teamName = snapNcaaById[p.team];
+    const liveTeamId = teamName ? ncaaByName[teamName] : null;
+    if (!liveTeamId) { console.warn('  Skipping pick — ncaa_team not found: ' + p.team + ' (' + teamName + ')'); pickFail++; continue; }
+    const r = await httpReq('POST', BASE_URL + '/api/collections/draft_picks/records', {
+      pool_team: newPoolTeamId, team: liveTeamId, user: p.user || '', draft_round: p.draft_round, pick_number: p.pick_number
+    });
+    if (r.status !== 200) { console.error('  Failed pick', teamName, r.body); pickFail++; }
+    else pickOk++;
+  }
+  console.log('  Restored ' + pickOk + ' picks (' + pickFail + ' failed)');
+  console.log('\nRestore complete.');
+}
+main().catch(e => { console.error(e); process.exit(1); });

--- a/scripts/snapshot-draft.cjs
+++ b/scripts/snapshot-draft.cjs
@@ -1,0 +1,84 @@
+#!/usr/bin/env node
+/**
+ * Snapshots pool_teams, draft_orders, draft_picks, ncaa_teams from PocketBase
+ * into scripts/draft-snapshot.json.
+ *
+ * Usage: node scripts/snapshot-draft.cjs
+ */
+const https = require('https');
+const http = require('http');
+const fs = require('fs');
+const path = require('path');
+
+const envPath = path.join(__dirname, '../.env');
+const envVars = {};
+if (fs.existsSync(envPath)) {
+  fs.readFileSync(envPath, 'utf8').split('\n').forEach(line => {
+    const m = line.match(/^([^#=]+)=(.*)/);
+    if (m) envVars[m[1].trim()] = m[2].trim().replace(/^['"]|['"]$/g, '');
+  });
+}
+const BASE_URL = (envVars.POCKETBASE_URL || process.env.POCKETBASE_URL || '').replace(/\/$/, '');
+const EMAIL = envVars.POCKETBASE_ADMIN_EMAIL || process.env.POCKETBASE_ADMIN_EMAIL;
+const PASSWORD = envVars.POCKETBASE_ADMIN_PASSWORD || process.env.POCKETBASE_ADMIN_PASSWORD;
+
+function httpReq(method, urlStr, body, token) {
+  return new Promise((resolve, reject) => {
+    const parsed = new URL(urlStr);
+    const lib = parsed.protocol === 'https:' ? https : http;
+    const data = body ? JSON.stringify(body) : null;
+    const headers = { 'Content-Type': 'application/json' };
+    if (token) headers['Authorization'] = 'Bearer ' + token;
+    if (data) headers['Content-Length'] = Buffer.byteLength(data);
+    const req = lib.request({
+      hostname: parsed.hostname,
+      port: parsed.port || (parsed.protocol === 'https:' ? 443 : 80),
+      path: parsed.pathname + parsed.search,
+      method, headers
+    }, (res) => {
+      let raw = '';
+      res.on('data', d => raw += d);
+      res.on('end', () => { try { resolve(JSON.parse(raw)); } catch { resolve(raw); } });
+    });
+    req.on('error', reject);
+    if (data) req.write(data);
+    req.end();
+  });
+}
+
+async function getAll(token, collection) {
+  let page = 1, items = [];
+  while (true) {
+    const url = BASE_URL + '/api/collections/' + collection + '/records?page=' + page + '&perPage=200';
+    const data = await httpReq('GET', url, null, token);
+    if (!data.items) { console.error('  Unexpected response for', collection, JSON.stringify(data).slice(0, 200)); break; }
+    items = items.concat(data.items);
+    if (page >= (data.totalPages || 1)) break;
+    page++;
+  }
+  return items;
+}
+
+async function main() {
+  const auth = await httpReq('POST', BASE_URL + '/api/collections/_superusers/auth-with-password', { identity: EMAIL, password: PASSWORD });
+  const token = auth.token;
+  if (!token) { console.error('Auth failed', JSON.stringify(auth)); process.exit(1); }
+  console.log('Authenticated. Fetching...');
+
+  const [poolTeams, draftOrders, draftPicks, ncaaTeams] = await Promise.all([
+    getAll(token, 'pool_teams'),
+    getAll(token, 'draft_orders'),
+    getAll(token, 'draft_picks'),
+    getAll(token, 'ncaa_teams'),
+  ]);
+
+  const snapshot = { snapshotAt: new Date().toISOString(), pool_teams: poolTeams, draft_orders: draftOrders, draft_picks: draftPicks, ncaa_teams: ncaaTeams };
+  const outPath = path.join(__dirname, 'draft-snapshot.json');
+  fs.writeFileSync(outPath, JSON.stringify(snapshot, null, 2));
+  console.log('Snapshot saved to ' + outPath);
+  console.log('  pool_teams:   ' + poolTeams.length);
+  console.log('  draft_orders: ' + draftOrders.length);
+  console.log('  draft_picks:  ' + draftPicks.length);
+  console.log('  ncaa_teams:   ' + ncaaTeams.length);
+}
+main().catch(e => { console.error(e); process.exit(1); });

--- a/src/routes/leaderboard/+page.server.ts
+++ b/src/routes/leaderboard/+page.server.ts
@@ -1,11 +1,21 @@
-import { buildLeaderboard } from '$lib/pocketbase';
+import { adminPb, ensureAdminAuth, buildLeaderboard } from '$lib/pocketbase';
+import type { DraftPick, GameResult, PoolTeam } from '$lib/types';
 import type { PageServerLoad } from './$types';
 
 export const load: PageServerLoad = async () => {
 	try {
-		const leaderboard = await buildLeaderboard();
-		return { leaderboard };
+		await ensureAdminAuth();
+		const [leaderboard, picks, results, poolTeams] = await Promise.all([
+			buildLeaderboard(),
+			adminPb.collection('draft_picks').getFullList<DraftPick>({
+				sort: 'pick_number',
+				expand: 'team,pool_team'
+			}),
+			adminPb.collection('game_results').getFullList<GameResult>({ expand: 'team' }),
+			adminPb.collection('pool_teams').getFullList<PoolTeam>({ sort: 'name' })
+		]);
+		return { leaderboard, picks, results, poolTeams };
 	} catch {
-		return { leaderboard: [] };
+		return { leaderboard: [], picks: [], results: [], poolTeams: [] };
 	}
 };

--- a/src/routes/leaderboard/+page.svelte
+++ b/src/routes/leaderboard/+page.svelte
@@ -1,10 +1,86 @@
 <script lang="ts">
 	import fordLogo from '$lib/assets/ford_logo.png';
 	import * as Card from '$lib/components/ui/card';
-	import Leaderboard from '$lib/components/Leaderboard.svelte';
 	import Trophy from '@lucide/svelte/icons/trophy';
+	import type { NcaaTeam } from '$lib/types';
+	import { TOURNAMENT_ROUNDS } from '$lib/types';
 
 	let { data } = $props();
+
+	const roundLabels: Record<string, string> = {
+		round_1: 'R64', round_2: 'R32', round_3: 'S16', round_4: 'E8', semifinal: 'FF', final: 'Champ'
+	};
+	const roundFull: Record<string, string> = {
+		round_1: 'Round of 64', round_2: 'Round of 32', round_3: 'Sweet 16',
+		round_4: 'Elite 8', semifinal: 'Final Four', final: 'Championship'
+	};
+	const regionColor: Record<string, string> = {
+		East: 'bg-blue-100 text-blue-700 dark:bg-blue-900/40 dark:text-blue-300',
+		West: 'bg-purple-100 text-purple-700 dark:bg-purple-900/40 dark:text-purple-300',
+		South: 'bg-green-100 text-green-700 dark:bg-green-900/40 dark:text-green-300',
+		Midwest: 'bg-orange-100 text-orange-700 dark:bg-orange-900/40 dark:text-orange-300'
+	};
+	const medals = ['🥇', '🥈', '🥉'];
+
+	// teamId -> set of rounds won
+	const wonTeamRounds = $derived.by(() => {
+		const map: Record<string, Set<string>> = {};
+		for (const r of data.results ?? []) {
+			if (!r.won) continue;
+			if (!map[r.team]) map[r.team] = new Set();
+			map[r.team].add(r.tournament_round);
+		}
+		return map;
+	});
+
+	// set of eliminated team ids
+	const eliminatedTeams = $derived.by(() => {
+		const s = new Set<string>();
+		for (const pick of data.picks ?? []) {
+			const team = pick.expand?.team as NcaaTeam | undefined;
+			if (team?.eliminated_round) s.add(team.id);
+		}
+		return s;
+	});
+
+	// ptId -> sorted picks with team data
+	const poolTeamPicks = $derived.by(() => {
+		const map: Record<string, { team: NcaaTeam; pick_number: number; draft_round: number }[]> = {};
+		for (const pick of data.picks ?? []) {
+			const ptId = (pick.pool_team as string) || pick.expand?.pool_team?.id;
+			if (!ptId) continue;
+			const team = pick.expand?.team as NcaaTeam | undefined;
+			if (!team) continue;
+			if (!map[ptId]) map[ptId] = [];
+			map[ptId].push({ team, pick_number: pick.pick_number, draft_round: pick.draft_round });
+		}
+		for (const id of Object.keys(map)) map[id].sort((a, b) => a.pick_number - b.pick_number);
+		return map;
+	});
+
+	function highestRound(teamId: string): string | null {
+		const rounds = wonTeamRounds[teamId];
+		if (!rounds || rounds.size === 0) return null;
+		for (let i = TOURNAMENT_ROUNDS.length - 1; i >= 0; i--) {
+			if (rounds.has(TOURNAMENT_ROUNDS[i])) return TOURNAMENT_ROUNDS[i];
+		}
+		return null;
+	}
+
+	function aliveCount(ptId: string): number {
+		return (poolTeamPicks[ptId] ?? []).filter(p => !eliminatedTeams.has(p.team.id)).length;
+	}
+
+	// Pre-compute per-entry round breakdown for the table
+	const breakdownByTeam = $derived.by(() => {
+		return data.leaderboard.map(entry => {
+			const byRound: Record<string, number> = {};
+			for (const b of entry.breakdown) {
+				byRound[b.round] = (byRound[b.round] ?? 0) + b.points;
+			}
+			return byRound;
+		});
+	});
 </script>
 
 <svelte:head>
@@ -13,7 +89,7 @@
 
 <div class="min-h-screen bg-background">
 	<header class="border-b bg-primary px-4 py-4 text-primary-foreground">
-		<div class="mx-auto flex max-w-2xl items-center gap-3">
+		<div class="mx-auto flex max-w-6xl items-center gap-3">
 			<img src={fordLogo} alt="Ford's Pool" class="h-9 w-9 rounded-full bg-white object-contain p-0.5" />
 			<div>
 				<h1 class="text-xl font-bold leading-tight">Ford's Pool 2026</h1>
@@ -23,25 +99,109 @@
 		</div>
 	</header>
 
-	<main class="mx-auto max-w-2xl px-4 py-8">
-		<Card.Card>
-			<Card.CardHeader>
-				<Card.CardTitle class="flex items-center gap-2 text-2xl font-bold text-primary">
-					<Trophy class="h-6 w-6" /> Leaderboard
-				</Card.CardTitle>
-				{#if data.leaderboard.length > 0}
-					<p class="text-sm text-muted-foreground">
-						Click any row to see score breakdown.
-					</p>
-				{/if}
-			</Card.CardHeader>
-			<Card.CardContent>
-				<Leaderboard
-					entries={data.leaderboard}
-					showBreakdown={true}
-				/>
-			</Card.CardContent>
-		</Card.Card>
+	<main class="mx-auto max-w-6xl px-4 py-8 space-y-6">
+		<div class="flex items-center gap-2">
+			<Trophy class="h-5 w-5 text-primary" />
+			<h2 class="text-xl font-bold">Standings</h2>
+			{#if data.leaderboard.length > 0}
+				<span class="text-sm text-muted-foreground ml-2">· scores update as results are recorded</span>
+			{/if}
+		</div>
+
+		{#if data.leaderboard.length === 0}
+			<Card.Card>
+				<Card.CardContent class="py-12 text-center text-muted-foreground">
+					No scores yet — check back once the tournament begins.
+				</Card.CardContent>
+			</Card.Card>
+		{:else}
+			<!-- Pool team cards -->
+			<div class="grid gap-4 sm:grid-cols-2 lg:grid-cols-3 xl:grid-cols-4 2xl:grid-cols-5">
+				{#each data.leaderboard as entry, i}
+					{@const ptId = entry.poolTeam.id}
+					{@const picks = poolTeamPicks[ptId] ?? []}
+					{@const alive = aliveCount(ptId)}
+					<Card.Card class="flex flex-col {i === 0 ? 'ring-2 ring-primary' : ''}">
+						<Card.CardHeader class="pb-2 pt-3 px-3">
+							<div class="flex items-start justify-between gap-1">
+								<div class="flex items-center gap-1.5 min-w-0">
+									<span class="text-base leading-none shrink-0">
+										{#if i < 3}{medals[i]}{:else}<span class="text-sm font-bold text-muted-foreground">{i + 1}</span>{/if}
+									</span>
+									<span class="text-sm font-bold leading-tight truncate">{entry.poolTeam.name}</span>
+								</div>
+								<span class="text-lg font-black tabular-nums text-primary shrink-0">{entry.total}</span>
+							</div>
+							<div class="flex items-center gap-2 mt-1">
+								<span class="text-xs text-muted-foreground">{alive}/{picks.length} alive</span>
+								{#if alive === picks.length && picks.length > 0}
+									<span class="text-xs bg-green-100 text-green-700 dark:bg-green-900/40 dark:text-green-300 rounded px-1.5 py-0.5 font-medium">All alive</span>
+								{:else if alive === 0 && picks.length > 0}
+									<span class="text-xs bg-red-100 text-red-700 dark:bg-red-900/40 dark:text-red-300 rounded px-1.5 py-0.5 font-medium">All out</span>
+								{/if}
+							</div>
+						</Card.CardHeader>
+						<Card.CardContent class="px-3 pb-3 pt-0 flex-1">
+							<div class="flex flex-col divide-y divide-border">
+								{#each picks as { team }}
+									{@const isElim = eliminatedTeams.has(team.id)}
+									{@const adv = highestRound(team.id)}
+									{@const rc = regionColor[team.region] ?? 'bg-muted text-muted-foreground'}
+									<div class="py-1.5 flex items-center gap-1.5 {isElim ? 'opacity-40' : ''}">
+										<span class="w-5 shrink-0 text-right text-xs font-bold tabular-nums text-muted-foreground/70">#{team.seed}</span>
+										<span class="flex-1 text-xs font-medium truncate {isElim ? 'line-through' : ''}">{team.name}</span>
+										<span class="shrink-0 rounded px-1 py-0.5 text-xs leading-none {rc}">{team.region.slice(0,1)}</span>
+										{#if adv}
+											<span class="shrink-0 rounded px-1 py-0.5 text-xs font-bold leading-none bg-accent/20 text-accent" title={roundFull[adv]}>{roundLabels[adv]}</span>
+										{/if}
+										{#if isElim}
+											<span class="shrink-0 text-xs text-destructive/60">✕</span>
+										{/if}
+									</div>
+								{/each}
+								{#if picks.length === 0}
+									<p class="py-2 text-xs text-muted-foreground italic">No picks</p>
+								{/if}
+							</div>
+						</Card.CardContent>
+					</Card.Card>
+				{/each}
+			</div>
+
+			<!-- Score breakdown table -->
+			<div>
+				<h3 class="text-sm font-semibold text-muted-foreground uppercase tracking-wider mb-3">Score Breakdown by Round</h3>
+				<div class="overflow-x-auto rounded-lg border">
+					<table class="w-full text-sm">
+						<thead>
+							<tr class="bg-primary text-primary-foreground">
+								<th class="px-4 py-2.5 w-10 text-center font-semibold">#</th>
+								<th class="px-4 py-2.5 text-left font-semibold">Team</th>
+								{#each TOURNAMENT_ROUNDS as round}
+									<th class="px-2 py-2.5 text-center font-semibold text-xs" title={roundFull[round]}>{roundLabels[round]}</th>
+								{/each}
+								<th class="px-4 py-2.5 text-right font-semibold">Total</th>
+							</tr>
+						</thead>
+						<tbody>
+							{#each data.leaderboard as entry, i}
+								{@const byRound = breakdownByTeam[i]}
+								<tr class="border-b {i % 2 === 0 ? 'bg-card' : 'bg-muted/40'}">
+									<td class="px-4 py-2 text-center text-muted-foreground">{i + 1}</td>
+									<td class="px-4 py-2 font-medium truncate max-w-[160px]">{entry.poolTeam.name}</td>
+									{#each TOURNAMENT_ROUNDS as round}
+										<td class="px-2 py-2 text-center tabular-nums text-xs {byRound[round] ? 'font-bold text-accent' : 'text-muted-foreground/40'}">
+											{byRound[round] ?? '—'}
+										</td>
+									{/each}
+									<td class="px-4 py-2 text-right font-black tabular-nums text-primary">{entry.total}</td>
+								</tr>
+							{/each}
+						</tbody>
+					</table>
+				</div>
+			</div>
+		{/if}
 	</main>
 
 	<footer class="border-t bg-muted/50 py-4 text-center text-xs text-muted-foreground">


### PR DESCRIPTION
… scripts

- Leaderboard redesigned as card-per-pool-team showing each NCAA team with seed, region, round advancement badge, and eliminated state
- Score breakdown table below cards with per-round columns
- Leaderboard server load now fetches picks (with team/pool_team expand) and game_results directly
- snapshot-draft.cjs: exports pool_teams, draft_orders, draft_picks, ncaa_teams to draft-snapshot.json
- restore-draft.cjs: clears and re-creates pool_teams/orders/picks from snapshot, matching ncaa_teams by name