### PR TITLE
Scores: show all teams per round, add First Four regions, remove lead…

### DIFF
--- a/scripts/draft-snapshot.json
+++ b/scripts/draft-snapshot.json
@@ -1,5 +1,5 @@
 {
-  "snapshotAt": "2026-03-17T18:31:09.350Z",
+  "snapshotAt": "2026-03-21T07:23:52.865Z",
   "pool_teams": [
     {
       "collectionId": "pbc_2152491242",
@@ -912,7 +912,7 @@
       "id": "msd3rlbja75klgp",
       "pick_number": 57,
       "pool_team": "3mqopegilo4kyes",
-      "team": "s366ogcsgmqnwq4",
+      "team": "51lu6ulcw20ppzj",
       "user": "nk7q0xd859ztdn3"
     },
     {
@@ -932,7 +932,7 @@
       "id": "shgqkr73ye6efpa",
       "pick_number": 60,
       "pool_team": "8lbsjocexixpq4p",
-      "team": "uh9ctrfznn0dume",
+      "team": "u0lx64n4fdfd74r",
       "user": "nk7q0xd859ztdn3"
     },
     {
@@ -940,9 +940,29 @@
       "collectionName": "draft_picks",
       "draft_round": 6,
       "id": "n361ajpphjqrwa2",
-      "pick_number": 60,
+      "pick_number": 59,
       "pool_team": "874jxqqzavwx2pw",
       "team": "0h78b1zgkk1c44l",
+      "user": "nk7q0xd859ztdn3"
+    },
+    {
+      "collectionId": "pbc_2345463699",
+      "collectionName": "draft_picks",
+      "draft_round": 6,
+      "id": "7epgh82ltlfrxga",
+      "pick_number": 61,
+      "pool_team": "8lbsjocexixpq4p",
+      "team": "8ag7891l2fd77ay",
+      "user": "nk7q0xd859ztdn3"
+    },
+    {
+      "collectionId": "pbc_2345463699",
+      "collectionName": "draft_picks",
+      "draft_round": 6,
+      "id": "4uyjhldgzpxrv6n",
+      "pick_number": 62,
+      "pool_team": "3mqopegilo4kyes",
+      "team": "33ezwf6odip56li",
       "user": "nk7q0xd859ztdn3"
     }
   ],
@@ -1465,18 +1485,9 @@
       "collectionName": "ncaa_teams",
       "eliminated_round": "",
       "id": "0h78b1zgkk1c44l",
-      "name": "Howard",
+      "name": "Howard Bison",
       "region": "Midwest",
       "seed": 16
-    },
-    {
-      "collectionId": "pbc_725768535",
-      "collectionName": "ncaa_teams",
-      "eliminated_round": "",
-      "id": "s366ogcsgmqnwq4",
-      "name": "Texas",
-      "region": "First Four 2",
-      "seed": 11
     },
     {
       "collectionId": "pbc_725768535",
@@ -1492,7 +1503,7 @@
       "collectionName": "ncaa_teams",
       "eliminated_round": "",
       "id": "uwx4kvgd5pfyyjk",
-      "name": "Prairie View / Lehigh",
+      "name": "SIUE Cougars",
       "region": "South",
       "seed": 16
     },
@@ -1501,7 +1512,7 @@
       "collectionName": "ncaa_teams",
       "eliminated_round": "",
       "id": "9dlsrb4vosoqgi6",
-      "name": "LIU Sharks",
+      "name": "Montana State Bobcats",
       "region": "West",
       "seed": 16
     },
@@ -1509,8 +1520,35 @@
       "collectionId": "pbc_725768535",
       "collectionName": "ncaa_teams",
       "eliminated_round": "",
-      "id": "uh9ctrfznn0dume",
-      "name": "SMU",
+      "id": "0cap4362xbcv270",
+      "name": "American Eagles",
+      "region": "East",
+      "seed": 16
+    },
+    {
+      "collectionId": "pbc_725768535",
+      "collectionName": "ncaa_teams",
+      "eliminated_round": "",
+      "id": "u0lx64n4fdfd74r",
+      "name": "Furman Paladins",
+      "region": "East",
+      "seed": 15
+    },
+    {
+      "collectionId": "pbc_725768535",
+      "collectionName": "ncaa_teams",
+      "eliminated_round": "",
+      "id": "51lu6ulcw20ppzj",
+      "name": "Tennessee State Tigers",
+      "region": "Midwest",
+      "seed": 15
+    },
+    {
+      "collectionId": "pbc_725768535",
+      "collectionName": "ncaa_teams",
+      "eliminated_round": "",
+      "id": "8ag7891l2fd77ay",
+      "name": "SMU Mustangs",
       "region": "First Four",
       "seed": 11
     },
@@ -1518,10 +1556,10 @@
       "collectionId": "pbc_725768535",
       "collectionName": "ncaa_teams",
       "eliminated_round": "",
-      "id": "0cap4362xbcv270",
-      "name": "Siena Saints",
-      "region": "East",
-      "seed": 16
+      "id": "33ezwf6odip56li",
+      "name": "Texas Longhorns",
+      "region": "First Four 2",
+      "seed": 11
     }
   ]
 }

--- a/src/routes/admin/scores/+page.server.ts
+++ b/src/routes/admin/scores/+page.server.ts
@@ -1,5 +1,5 @@
 import { fail } from '@sveltejs/kit';
-import { adminPb, ensureAdminAuth, buildLeaderboard } from '$lib/pocketbase';
+import { adminPb, ensureAdminAuth } from '$lib/pocketbase';
 import { gameResultSchema, isTeamAlive } from '$lib/types';
 import type { Actions, PageServerLoad } from './$types';
 import type { NcaaTeam, GameResult } from '$lib/types';
@@ -7,14 +7,13 @@ import type { NcaaTeam, GameResult } from '$lib/types';
 export const load: PageServerLoad = async () => {
 	await ensureAdminAuth();
 	try {
-		const [teams, results, leaderboard] = await Promise.all([
+		const [teams, results] = await Promise.all([
 			adminPb.collection('ncaa_teams').getFullList<NcaaTeam>({ sort: 'region,seed' }),
-			adminPb.collection('game_results').getFullList<GameResult>({ expand: 'team' }),
-			buildLeaderboard()
+			adminPb.collection('game_results').getFullList<GameResult>({ expand: 'team' })
 		]);
-		return { teams, results, leaderboard };
+		return { teams, results };
 	} catch {
-		return { teams: [], results: [], leaderboard: [] };
+		return { teams: [], results: [] };
 	}
 };
 

--- a/src/routes/admin/scores/+page.svelte
+++ b/src/routes/admin/scores/+page.svelte
@@ -5,13 +5,11 @@
 	import * as Card from '$lib/components/ui/card';
 	import { Separator } from '$lib/components/ui/separator';
 	import { TOURNAMENT_ROUNDS, REGIONS, isTeamAlive } from '$lib/types';
-	import Trophy from '@lucide/svelte/icons/trophy';
 	import ChartBar from '@lucide/svelte/icons/bar-chart';
 	import CircleCheck from '@lucide/svelte/icons/circle-check';
 	import CircleX from '@lucide/svelte/icons/circle-x';
 	import Trash from '@lucide/svelte/icons/trash';
 	import ArrowLeftRight from '@lucide/svelte/icons/arrow-left-right';
-	import LeaderboardComponent from '$lib/components/Leaderboard.svelte';
 
 	let { data, form } = $props();
 
@@ -25,8 +23,9 @@
 	};
 
 	const roundOrder = TOURNAMENT_ROUNDS;
+	// round_1 includes 2 First Four games (2 extra losers) + 32 main bracket = 34
 	const requiredLosers: Record<string, number> = {
-		round_1: 32, round_2: 16, round_3: 8, round_4: 4, semifinal: 2, final: 1
+		round_1: 34, round_2: 16, round_3: 8, round_4: 4, semifinal: 2, final: 1
 	};
 
 	// ── Record tab ────────────────────────────────────────────────────────────
@@ -35,9 +34,21 @@
 	// Track which rounds are locally known to be complete (survives invalidateAll)
 	let completedRounds = $state<Set<string>>(new Set());
 
-	let activeTeams = $derived(data.teams.filter((t) => isTeamAlive(t)));
+	const MAIN_REGIONS = new Set(['East', 'West', 'South', 'Midwest', 'First Four', 'First Four 2']);
+	const ALL_REGIONS = ['East', 'West', 'South', 'Midwest', 'First Four', 'First Four 2'] as const;
+	let activeTeams = $derived(data.teams.filter((t) => isTeamAlive(t) && MAIN_REGIONS.has(t.region)));
 	let roundResultTeamIds = $derived(new Set(data.results.filter((r) => r.tournament_round === selectedRound).map((r) => r.team)));
+	// Eligible = alive teams not yet recorded for this round (used for submit count/validation)
 	let eligibleTeams = $derived(activeTeams.filter((t) => !roundResultTeamIds.has(t.id)));
+
+	// Rounds in order — teams eliminated in a round BEFORE selectedRound were not in this round
+	const roundIndex = $derived(TOURNAMENT_ROUNDS.indexOf(selectedRound));
+	const priorRounds = $derived(new Set(TOURNAMENT_ROUNDS.slice(0, roundIndex)));
+
+	// Display: all teams that played in selectedRound = main-region teams NOT eliminated before this round
+	let allRoundTeams = $derived(data.teams.filter((t) =>
+		MAIN_REGIONS.has(t.region) && !priorRounds.has(t.eliminated_round as string)
+	));
 
 	function isRoundComplete(round: string): boolean {
 		return completedRounds.has(round) ||
@@ -298,10 +309,9 @@
 		<ChartBar class="h-7 w-7" /> Tournament Scoring
 	</h1>
 
-	<div class="grid gap-6 xl:grid-cols-[1fr_380px]">
+	<div class="space-y-6">
 
-		<!-- Left -->
-		<div class="space-y-6">
+
 			<Card.Card class="border-primary/30">
 				<Card.CardHeader class="pb-3">
 					<div class="flex gap-1 rounded-lg bg-muted p-1 w-fit">
@@ -389,14 +399,14 @@
 							{/each}
 						</div>
 
-						{#if eligibleTeams.length === 0}
+						{#if allRoundTeams.length === 0}
 							<p class="text-sm text-accent text-center py-3 flex items-center justify-center gap-1.5">
 								<CircleCheck class="h-4 w-4" /> All results recorded. Use Corrections tab to fix any mistakes.
 							</p>
 						{:else}
 							<div class="grid gap-4 sm:grid-cols-2 xl:grid-cols-4">
-								{#each REGIONS as region}
-									{@const regionTeams = eligibleTeams.filter((t) => t.region === region)}
+								{#each ALL_REGIONS as region}
+									{@const regionTeams = allRoundTeams.filter((t) => t.region === region)}
 									{#if regionTeams.length > 0}
 										<div class="space-y-1">
 											<div class="flex items-center justify-between mb-2">
@@ -408,16 +418,35 @@
 											</div>
 											{#each regionTeams as team}
 												{@const isLoser = selectedLosers.has(team.id)}
-												<button type="button" onclick={() => toggleLoser(team.id)}
+												{@const alreadyRecorded = roundResultTeamIds.has(team.id)}
+												{@const recordedResult = data.results.find(r => r.team === team.id && r.tournament_round === selectedRound)}
+												<button type="button"
+													onclick={() => !alreadyRecorded && toggleLoser(team.id)}
+													disabled={alreadyRecorded}
 													class="flex w-full items-center gap-2 rounded px-2 py-1 text-xs transition-colors
-														{isLoser ? 'bg-destructive/20 text-destructive ring-1 ring-destructive/40' : 'bg-muted/50 hover:bg-muted'}">
-													{#if isLoser}
+														{alreadyRecorded
+															? recordedResult?.won
+																? 'bg-accent/10 text-accent/70 cursor-default opacity-60'
+																: 'bg-destructive/10 text-destructive/70 cursor-default opacity-60'
+															: isLoser
+																? 'bg-destructive/20 text-destructive ring-1 ring-destructive/40'
+																: 'bg-muted/50 hover:bg-muted'}">
+													{#if alreadyRecorded}
+														{#if recordedResult?.won}
+															<CircleCheck class="h-3 w-3 shrink-0 text-accent/60" />
+														{:else}
+															<CircleX class="h-3 w-3 shrink-0 text-destructive/60" />
+														{/if}
+													{:else if isLoser}
 														<CircleX class="h-3 w-3 shrink-0 text-destructive" />
 													{:else}
 														<CircleCheck class="h-3 w-3 shrink-0 text-muted-foreground/40" />
 													{/if}
 													<span class="w-4 text-right font-mono text-muted-foreground shrink-0">{team.seed}</span>
 													<span class="flex-1 truncate text-left font-medium">{team.name}</span>
+													{#if alreadyRecorded}
+														<span class="shrink-0 text-xs font-bold opacity-50">{recordedResult?.won ? 'W' : 'L'}</span>
+													{/if}
 												</button>
 											{/each}
 										</div>
@@ -492,24 +521,5 @@
 					{/if}
 				</Card.CardContent>
 			</Card.Card>
-		</div>
-
-		<!-- Right: Leaderboard -->
-		<div>
-			<Card.Card>
-				<Card.CardHeader class="pb-2">
-					<div class="flex items-center justify-between">
-						<Card.CardTitle class="flex items-center gap-2">
-							<Trophy class="h-4 w-4" /> Leaderboard
-						</Card.CardTitle>
-						<a href="/leaderboard" target="_blank" class="text-xs text-muted-foreground hover:text-primary underline">Public view ↗</a>
-					</div>
-				</Card.CardHeader>
-				<Card.CardContent>
-					<LeaderboardComponent entries={data.leaderboard} showBreakdown={true} />
-				</Card.CardContent>
-			</Card.Card>
-		</div>
-
 	</div>
 </div>


### PR DESCRIPTION
…erboard

- Show all teams that played in the selected round (not just unrecorded ones); already-recorded teams appear greyed out with W/L badge
- Include First Four and First Four 2 regions in round_1 display
- requiredLosers for round_1 updated to 34 (32 main bracket + 2 First Four)
- Remove leaderboard right column from scores page; collapse to single column
- Remove buildLeaderboard from scores server load
- Fix ncaa_teams data: add Furman Paladins (East #15), Tennessee State Tigers (Midwest #15); correct #16 seed names; re-add SMU/Texas as First Four teams
- Update draft-snapshot.json to reflect corrected state (66 teams, 62 picks)